### PR TITLE
Fix some issues related to circular import

### DIFF
--- a/nau_openedx_extensions/edxapp_wrapper/backends/registration_l_v1.py
+++ b/nau_openedx_extensions/edxapp_wrapper/backends/registration_l_v1.py
@@ -1,8 +1,6 @@
 """ Registration edxapp backend abstraction """
 from __future__ import absolute_import, unicode_literals
 
-from openedx.core.djangoapps.user_authn.views.registration_form import get_registration_extension_form
-
 from common.djangoapps.third_party_auth.saml import EdXSAMLIdentityProvider  # pylint: disable=import-error
 
 
@@ -11,3 +9,13 @@ def get_edx_saml_identity_provider():
     Gets edxapp SAML default identity provider class
     """
     return EdXSAMLIdentityProvider
+
+
+def get_registration_extension_form(*args, **kwargs):
+    """
+    Convenience function for getting the custom form set in settings.REGISTRATION_EXTENSION_FORM.
+    An example form app for this can be found at http://github.com/open-craft/custom-form-app
+    """
+    from openedx.core.djangoapps.user_authn.views.registration_form import get_registration_extension_form
+
+    return get_registration_extension_form(*args, **kwargs)

--- a/nau_openedx_extensions/third_party_auth/providers/saml.py
+++ b/nau_openedx_extensions/third_party_auth/providers/saml.py
@@ -90,6 +90,10 @@ def _apply_saml_overrides(*args, **kwargs):  # pylint: disable=unused-argument
     registration forms
     """
     custom_form = get_registration_extension_form()
+
+    if not custom_form:
+        return
+
     form_desc = kwargs["form_desc"]
 
     for field_name, _field in custom_form.fields.items():


### PR DESCRIPTION
# Description

This PR fix the circular import error; and LTIProviderConfig and _apply_saml_overrides imports.

I made two changes:
- Implement get_registration_extension_form instead of importing it
- Check if the custom form exists before using it

## Related
- https://plataforma-nau.atlassian.net/browse/FAN-49