### PR TITLE
feat: replace course enrollment admin screen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ virtual_environment: ## create virtual environment
 	test -d venv || virtualenv venv --python=python3
 	. venv/bin/activate && python -m pip install -Ur requirements/base.txt
 	. venv/bin/activate && python -m pip install -Ur requirements/translations.txt
+	. venv/bin/activate && python -m pip install -Ur requirements/test.txt
 	touch venv/touchfile
 	@echo "Run on your shell to activate the new virtual environment:"
 	@echo "  . venv/bin/activate"

--- a/nau_openedx_extensions/student/admin.py
+++ b/nau_openedx_extensions/student/admin.py
@@ -1,6 +1,11 @@
 """
 Extension of course access role admin screen with export to csv action
 """
+from common.djangoapps.student.admin import (  # lint-amnesty, pylint: disable=import-error
+    CourseEnrollmentForm,
+    DisableEnrollmentAdminMixin,
+)
+from common.djangoapps.student.models import CourseEnrollment  # lint-amnesty, pylint: disable=import-error
 from django.contrib import admin
 
 from nau_openedx_extensions.utils.admin import ExportCsvMixin
@@ -48,3 +53,27 @@ class CourseAccessRoleProxyAdmin(admin.ModelAdmin, ExportCsvMixin):
             return instance.user.email
         except Exception as error:
             return str(error)
+
+
+# Unregister the default Django Admin screen for CourseEnrollment class.
+# Because the upstream version has performance problems.
+admin.site.unregister(CourseEnrollment)
+
+
+# Register the custom NAU Django Admin screen for CourseEnrollment class
+# Changes from upstream:
+# - remove the custom order by / sort;
+# - remove the select_related user;
+# - change search by user username or email;
+@admin.register(CourseEnrollment)
+class NAUCourseEnrollmentAdmin(DisableEnrollmentAdminMixin, admin.ModelAdmin):
+    """ Admin interface for the CourseEnrollment model. """
+    list_display = ('id', 'user', 'email', 'course_id', 'mode', 'is_active',)
+    list_filter = ('mode', 'is_active',)
+    raw_id_fields = ('user',)
+    search_fields = ('user__username', 'user__email')
+    form = CourseEnrollmentForm
+    search_help_text = "Search by user username or email"
+
+    def email(self, obj):
+        return obj.user.email


### PR DESCRIPTION
Replace the default not performant Django administration screen that searches course enrollments.
Changes from upstream:
- remove the custom order by / sort
- remove the select_related user;
- change search by user username or email

GN-1145