### PR TITLE
Increase max CCX enrollments

### DIFF
--- a/nau_openedx_extensions/settings/production.py
+++ b/nau_openedx_extensions/settings/production.py
@@ -84,3 +84,9 @@ def plugin_settings(settings):
     settings.XBLOCK_SETTINGS["ScormXBlock"] = {
         "STORAGE_FUNC": scorm_xblock_storage,
     }
+
+    #### Custom Courses for EDX (CCX) configuration
+    # Allow to increase the maximum number of studends allowed in a CCX (Custom Courses for edX).
+    settings.CCX_MAX_STUDENTS_ALLOWED = getattr(settings, "ENV_TOKENS", {}).get(
+        "CCX_MAX_STUDENTS_ALLOWED", settings.CCX_MAX_STUDENTS_ALLOWED
+    )


### PR DESCRIPTION
This PR allows to increase the `CCX_MAX_STUDENTS_ALLOWED` setting that on the edx-platform has an value of `200`, but we want to allow to increase/change it from the normal `lms.env.yml` file.

GN-1189