### PR TITLE
Ensure SAML users have a usable password

### DIFF
--- a/nau_openedx_extensions/third_party_auth/pipeline.py
+++ b/nau_openedx_extensions/third_party_auth/pipeline.py
@@ -3,9 +3,21 @@ Auth pipeline definitions.
 """
 from __future__ import absolute_import, unicode_literals
 
+import logging
+
 from django.conf import settings
 
+from edx_django_utils.user import (
+    generate_password,
+)  # pylint: disable=import-error,unused-import
+
+from common.djangoapps.student.models import (
+    UserAttribute,
+)  # pylint: disable=import-error,no-name-in-module
+
 from nau_openedx_extensions.custom_registration_form.models import NauUserExtendedModel
+
+log = logging.getLogger(__name__)
 
 
 def ensure_cartao_cidadao_data(strategy, details, user, uid, *args, **kwargs):
@@ -45,3 +57,26 @@ def ensure_cartao_cidadao_data(strategy, details, user, uid, *args, **kwargs):
 
     if changed:
         user.nauuserextendedmodel.save()
+
+
+# pylint: disable=unused-argument,keyword-arg-before-vararg
+def ensure_new_user_has_usable_password(backend, user=None, **kwargs):
+    """
+    This pipeline function assigns an usable password to an user in case that
+    the user has an unusable password on user creation. At the creation of new users
+    through some TPA providers, some of them are created with an unusable password,
+    a user with an unusable password cannot login properly in the platform if
+    the common.djangoapps.third_party.pipeline.set_logged_in_cookies step is enabled.
+
+    It should run after `social_core.pipeline.user.create_user` on the SOCIAL_AUTH_TPA_SAML_PIPELINE.
+    """
+
+    is_new = kwargs.get("is_new")
+
+    if user and is_new and not user.has_usable_password():
+        user.set_password(generate_password(length=25))
+        user.save()
+
+        UserAttribute.set_user_attribute(user, "auto_password_via_tpa_pipeline", "true")
+
+        log.info("Assign a usable password to the user %s on creation", user.username)

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -2,6 +2,7 @@
 celery<5.0
 Django==2.2.25
 edx-opaque-keys[django]==2.2.0
+edx-django-utils>=5.1.0
 openedx-filters==0.7.0
 pip-tools<5.4
 click==7.1.2


### PR DESCRIPTION
FAN-155

This pipeline function assigns an usable password to an user in case that the user has an unusable password on user creation.
At the creation of new users through some TPA providers, some of them are created with an unusable password, a user with an unusable password cannot login properly in the platform if the common.djangoapps.third_party.pipeline.set_logged_in_cookies step is enabled.

The command should run after `social_core.pipeline.user.create_user` on the `SOCIAL_AUTH_TPA_SAML_PIPELINE`.

This should solve the issues with the SAML authentication

@igobranco: Please review this PR. There might be some issues with some imports or dependencies that I was no able to solve. We should also test this in STAGE. Google accounts can be enabled for this purpose.