### PR TITLE
fix: empty nau extended model admin

### DIFF
--- a/nau_openedx_extensions/custom_registration_form/admin.py
+++ b/nau_openedx_extensions/custom_registration_form/admin.py
@@ -61,6 +61,6 @@ class NauUserExtendedModelAdmin(admin.ModelAdmin, ExportCsvMixin):
 
     def get_search_results(self, request, queryset, search_term):
         qs, use_distinct = super().get_search_results(request, queryset, search_term)
-        if not search_term or len(search_term) < 3:
+        if search_term and len(search_term) > 0 and len(search_term) < 3:
             qs = NauUserExtendedModel.objects.none()
         return use_read_replica_if_available(qs), use_distinct


### PR DESCRIPTION
The NAU Extended model admin screen
didn't allow to search empty, so it prevents the export of contacts to newsletter.
relates to fccn/nau-technical#66
relates to fccn/nau-technical#100