### PR TITLE
feat: add `allow_newsletter` field to account settings

### DIFF
--- a/nau_openedx_extensions/custom_registration_form/context_extender.py
+++ b/nau_openedx_extensions/custom_registration_form/context_extender.py
@@ -27,7 +27,7 @@ def get_fields(custom_model_instance):
     for field in custom_fields:
         if field.name not in allowed_fields:
             continue
-        if isinstance(field, (models.CharField, models.TextField)):
+        if isinstance(field, (models.CharField, models.TextField, models.BooleanField)):
             yield field
 
 

--- a/nau_openedx_extensions/custom_registration_form/context_extender.py
+++ b/nau_openedx_extensions/custom_registration_form/context_extender.py
@@ -44,14 +44,21 @@ def update_account_view(context, user, **kwargs):
         custom_model_instance = NauUserExtendedModel()
     finally:
         for field in get_fields(custom_model_instance):
-            extended_profile_fields.append(
-                {
-                    "field_name": _(field.name),  # pylint: disable=translation-of-non-string
-                    "field_label": _(field.verbose_name),  # pylint: disable=translation-of-non-string
-                    "field_type": "TextField" if not field.choices else "ListField",
-                    "field_options": [] if not field.choices else field.choices,
-                }
-            )
+            extended_profile_field = {
+                "field_name": _(field.name), # pylint: disable=translation-of-non-string
+                "field_label": _(field.verbose_name), # pylint: disable=translation-of-non-string
+            }
+            if isinstance(field, models.BooleanField):
+                extended_profile_field["field_type"] = "CheckboxField"
+                extended_profile_field["field_options"] = []
+            elif field.choices:
+                extended_profile_field["field_type"] = "ListField"
+                extended_profile_field["field_options"] = field.choices
+            else:
+                extended_profile_field["field_type"] = "TextField"
+                extended_profile_field["field_options"] = []
+
+            extended_profile_fields.append(extended_profile_field)
 
     context["extended_profile_fields"].extend(extended_profile_fields)
 

--- a/nau_openedx_extensions/custom_registration_form/context_extender.py
+++ b/nau_openedx_extensions/custom_registration_form/context_extender.py
@@ -45,8 +45,8 @@ def update_account_view(context, user, **kwargs):
     finally:
         for field in get_fields(custom_model_instance):
             extended_profile_field = {
-                "field_name": _(field.name), # pylint: disable=translation-of-non-string
-                "field_label": _(field.verbose_name), # pylint: disable=translation-of-non-string
+                "field_name": _(field.name),  # pylint: disable=translation-of-non-string
+                "field_label": _(field.verbose_name),  # pylint: disable=translation-of-non-string
             }
             if isinstance(field, models.BooleanField):
                 extended_profile_field["field_type"] = "CheckboxField"

--- a/nau_openedx_extensions/settings/common.py
+++ b/nau_openedx_extensions/settings/common.py
@@ -77,7 +77,7 @@ def plugin_settings(settings):
     settings.NAU_COURSE_MESSAGE_BATCH_SIZE = 50
     settings.NAU_COURSE_MESSAGE_RECIPIENT_FIELDS = ["profile__name", "email"]
     settings.NAU_CC_ALLOWED_SLUG = "cccmd:"
-    settings.NAU_ACCOUNTS_CC_VISIBLE_FIELDS = ["employment_situation", "nif"]
+    settings.NAU_ACCOUNTS_CC_VISIBLE_FIELDS = ["employment_situation", "nif", "allow_newsletter"]
     settings.SCORMXBLOCK_ASYNC_THRESHOLD = 500
     settings.NAU_SITE_CONFIGURATION_HELPERS_MODULE = (
         "nau_openedx_extensions.edxapp_wrapper.backends.site_configuration_helpers_l_v1"


### PR DESCRIPTION
### Description
This PR adds the `allow_newsletter` field _(Checkbox)_ in the Account Settings. This allows each user to update the value of the field.

### Related Issues
- https://github.com/fccn/nau-technical/issues/279
- https://github.com/eduNEXT/consulting-issues-mapping/issues/10

### Testing Instructions
1. Create a Tutor environment in the Redwood version.
2. Install this plugin with the changes in this PR.
3. Create a mount of `edx-platform` with the changes in [this PR](https://github.com/fccn/edx-platform/pull/19).
4. Update the `account.redirect_to_microfrontend` Waffle Flag. Set `Everyone` to `No`. This allows access to the legacy interface.
5. Go to `{lms_domain}/account/settings`
6. You should see the new checkbox field in the **Additional Information** section.
7. Try to update the field and verify that the value was updated in the model.

### Screenshots
![image](https://github.com/user-attachments/assets/05202cfe-4782-455f-b042-9561ae46c9fa)