### PR TITLE
fix: CourseOverview required field

### DIFF
--- a/nau_openedx_extensions/common/signals.py
+++ b/nau_openedx_extensions/common/signals.py
@@ -1,0 +1,24 @@
+"""
+NAU Custom code to skip Open edX ID Verification module.
+"""
+import logging
+
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
+log = logging.getLogger(__name__)
+
+
+@receiver(pre_save, sender=CourseOverview)
+def fix_course_overview_required_fields(sender, instance: CourseOverview, **kwargs):
+    """
+    Fix CourseOverview required fields before saving by
+    ensuring the CourseOverview has a valid entrance_exam_minimum_score_pct field.
+    The entrance_exam_minimum_score_pct field is required but has a default value of 0.65.
+    """
+    log.info(f"Pre-save signal triggered for CourseOverview: {instance.id}")
+    # Ensure the course_overview has a valid entrance_exam_minimum_score_pct
+    if instance.entrance_exam_minimum_score_pct is None:
+        instance.entrance_exam_minimum_score_pct = 0.65
+        log.info(f"Fix CourseOverview on pre_save: {instance.id}")

--- a/nau_openedx_extensions/signals.py
+++ b/nau_openedx_extensions/signals.py
@@ -1,7 +1,8 @@
 """
-File that contains the definition of all signals and its receivers.
+File that contains the definition of all signals and its receivers for LMS.
 """
 
+from nau_openedx_extensions.common.signals import fix_course_overview_required_fields  # pylint: disable=unused-import
 from nau_openedx_extensions.verify_student.id_verification import (  # pylint: disable=unused-import
     event_receiver_no_id_verify_for_enrollment_modes,
 )

--- a/nau_openedx_extensions/studio/apps.py
+++ b/nau_openedx_extensions/studio/apps.py
@@ -20,3 +20,10 @@ class NauOpenCmsConfig(AppConfig):
             },
         },
     }
+
+    def ready(self):
+        """
+        Method to perform actions after apps registry is ended
+        """
+        from nau_openedx_extensions.studio import \
+            signals  # pylint: disable=import-outside-toplevel,unused-import # noqa

--- a/nau_openedx_extensions/studio/management/commands/transfer_export_course_content.py
+++ b/nau_openedx_extensions/studio/management/commands/transfer_export_course_content.py
@@ -29,7 +29,6 @@ from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from lms.djangoapps.instructor_task.models import ReportStore  # lint-amnesty, pylint: disable=import-error
 from opaque_keys.edx.keys import CourseKey
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.site_configuration.models import (  # lint-amnesty, pylint: disable=import-error
     SiteConfiguration,
 )

--- a/nau_openedx_extensions/studio/signals.py
+++ b/nau_openedx_extensions/studio/signals.py
@@ -1,0 +1,4 @@
+"""
+Contains signals for the Open edX Studio application.
+"""
+from nau_openedx_extensions.common.signals import fix_course_overview_required_fields  # pylint: disable=unused-import


### PR DESCRIPTION
Implement pre-save signal to ensure valid
entrance_exam_minimum_score_pct in CourseOverview.

fccn/nau-technical#501


---

To test it, run this script. That simulates the current existing problem.

```python
from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
from opaque_keys.edx.keys import CourseKey

course_overviews = CourseOverview.objects.all()

for course_overview in course_overviews:
    print(f"id: {course_overview.id} display_name: {course_overview.display_name}")

if len(course_overviews)>0:
    course_overviews[0].delete()

course_overviews = CourseOverview.objects.all()
print(f"course overviews: {len(course_overviews)}")


course_key = CourseKey.from_string('course-v1:OpenedX+DemoX+DemoCourse')
course = modulestore().get_course(course_key)
course_overview = CourseOverview._create_or_update(course)
course_overview.entrance_exam_minimum_score_pct = None

course_overview.save()

```