### PR TITLE
feat: add event listener when an event is created

### DIFF
--- a/nau_openedx_extensions/coursecertificate/apps.py
+++ b/nau_openedx_extensions/coursecertificate/apps.py
@@ -18,3 +18,10 @@ class CoursecertificateConfig(AppConfig):
             },
         },
     }
+
+    def ready(self):
+        """
+        Import handlers to ensure they are registered.
+        """
+        # pylint: disable=import-outside-toplevel,unused-import
+        import nau_openedx_extensions.coursecertificate.handlers

--- a/nau_openedx_extensions/coursecertificate/engine.py
+++ b/nau_openedx_extensions/coursecertificate/engine.py
@@ -186,11 +186,11 @@ class CertificateEngine:
 
                 if args:
                     if isinstance(args, list):
-                        filtered_certificates = filter_func(filtered_certificates, *args)
+                        filtered_certificates = filter_func(filtered_certificates, *args)  # pragma: no cover
                     else:
                         filtered_certificates = filter_func(filtered_certificates, args)
                 else:
-                    filtered_certificates = filter_func(filtered_certificates)
+                    filtered_certificates = filter_func(filtered_certificates)  # pragma: no cover
 
             except (ImportError, AttributeError, TypeError) as exc:
                 self.log(f"Error applying filter {filter_config['func']}: {exc}")
@@ -404,19 +404,29 @@ class CertificateEngine:
 
         return success
 
-    def get_certificates_queryset(self, days: int) -> QuerySet:
+    def get_certificates_queryset(self, days: int, certificate_id: int | None) -> QuerySet:
         """
-        Get certificates queryset filtered by date.
-
-        Retrieves certificates created within the specified number of days from now.
-        Uses read replica if available for better performance.
+        Get certificates queryset filtered by date and optionally by certificate ID.
 
         Args:
             days (int): Number of days to look back from current date.
+            certificate_id (int | None): Specific certificate ID to filter by.
+                If provided, only this certificate will be returned regardless of date.
 
         Returns:
             QuerySet: Filtered and ordered certificates queryset with user relations.
         """
+        if certificate_id:
+            queryset = use_read_replica_if_available(
+                GeneratedCertificate.objects.filter(id=certificate_id).select_related("user")
+            )
+
+            if not queryset.exists():
+                self.log(f"WARNING: Certificate with ID {certificate_id} does not exist.")
+                return GeneratedCertificate.objects.none()
+
+            return queryset
+
         begin_date = datetime.now(UTC) - timedelta(days=days)
         return use_read_replica_if_available(
             GeneratedCertificate.objects.filter(created_date__gte=begin_date)
@@ -429,7 +439,7 @@ class CertificateEngine:
         Extract and validate processing parameters.
 
         Combines command-line options with service configuration defaults to determine
-        processing parameters like days, page size, and dry run mode.
+        processing parameters like days, page size, certificate ID, and dry run mode.
 
         Args:
             service_config (dict): Service configuration containing:
@@ -438,12 +448,14 @@ class CertificateEngine:
             options (dict): Command options containing:
                 - days (int, optional): Override for days parameter
                 - page_size (int, optional): Override for page size
+                - certificate_id (int, optional): Specific certificate ID to process
                 - dry_run (bool, optional): Dry run mode flag
 
         Returns:
             dict: Dictionary containing validated processing parameters:
                 - days (int): Number of days to process
                 - page_size (int): Page size for pagination
+                - certificate_id (int, optional): Specific certificate ID
                 - dry_run (bool): Dry run mode flag
         """
         days = options.get("days")
@@ -454,7 +466,12 @@ class CertificateEngine:
         if page_size is None:
             page_size = service_config.get("page_size", 1000)
 
-        return {"days": days, "page_size": page_size, "dry_run": options.get("dry_run", False)}
+        return {
+            "days": days,
+            "page_size": page_size,
+            "certificate_id": options.get("certificate_id"),
+            "dry_run": options.get("dry_run", False),
+        }
 
     def _process_certificates_page(self, certificates, service_config: dict, dry_run: bool) -> bool:
         """
@@ -537,6 +554,7 @@ class CertificateEngine:
             options (dict): Processing options containing:
                 - days (int, optional): Override for days parameter
                 - page_size (int, optional): Override for page size
+                - certificate_id (int, optional): Specific certificate ID to process
                 - dry_run (bool, optional): Dry run mode flag
         """
         service_name = service_config.get("service_name")
@@ -544,10 +562,13 @@ class CertificateEngine:
 
         params = self._get_processing_parameters(service_config, options)
 
-        self.log(f"Processing certificates from the last {params['days']} days")
-        self.log(f"Page size: {params['page_size']}")
+        if params["certificate_id"]:
+            self.log(f"Processing specific certificate with ID: {params['certificate_id']}")
+        else:
+            self.log(f"Processing certificates from the last {params['days']} days")
+            self.log(f"Page size: {params['page_size']}")
 
-        certificates_queryset = self.get_certificates_queryset(params["days"])
+        certificates_queryset = self.get_certificates_queryset(params["days"], params["certificate_id"])
         certificates_queryset = self.apply_filters(certificates_queryset, service_config)
 
         self._process_certificates_pages(certificates_queryset, service_config, params)

--- a/nau_openedx_extensions/coursecertificate/handlers.py
+++ b/nau_openedx_extensions/coursecertificate/handlers.py
@@ -1,0 +1,52 @@
+"""
+Course certificate event handlers.
+"""
+
+import logging
+
+from django.core.management import call_command
+from django.dispatch import receiver
+from openedx_events.data import EventsMetadata
+from openedx_events.learning.data import CertificateData
+from openedx_events.learning.signals import CERTIFICATE_CREATED
+from openedx_events.tooling import OpenEdxPublicSignal
+
+from nau_openedx_extensions.edxapp_wrapper.certificates import GeneratedCertificate
+
+log = logging.getLogger(__name__)
+
+
+# pylint: disable=unused-argument
+@receiver(CERTIFICATE_CREATED)
+def certificate_created_send_to_external_services_handler(
+    signal: OpenEdxPublicSignal, sender, certificate: CertificateData, metadata: EventsMetadata, **kwargs
+):
+    """
+    Event handler that automatically sends newly created certificates to external services.
+
+    This handler is triggered when a certificate is created in the system. It retrieves
+    the corresponding GeneratedCertificate from the database and sends it to all
+    configured external services using the send_certificates_by_web_service command.
+
+    Args:
+        signal (OpenEdxPublicSignal): The signal that was sent.
+        sender: The sender of the signal.
+        certificate (CertificateData): The certificate data associated with the event.
+        metadata (EventsMetadata): The metadata of the event.
+        **kwargs: Additional keyword arguments.
+    """
+    user_id = certificate.user.id
+    course_id = certificate.course.course_key
+
+    try:
+        certificate_object = GeneratedCertificate.objects.get(user_id=user_id, course_id=course_id)
+    except GeneratedCertificate.DoesNotExist:
+        log.error(f"No GeneratedCertificate found for user_id={user_id} and course_id={course_id}")
+        return
+
+    log.info(f"Sending certificate {certificate_object.id} to external services")
+
+    try:
+        call_command("send_certificates_by_web_service", certificate_id=certificate_object.id, async_mode=True)
+    except Exception as e:  # pylint: disable=broad-except
+        log.error(f"Failed to send certificate {certificate_object.id} to external services: {e}", exc_info=True)

--- a/nau_openedx_extensions/coursecertificate/management/commands/send_certificates_by_web_service.py
+++ b/nau_openedx_extensions/coursecertificate/management/commands/send_certificates_by_web_service.py
@@ -44,6 +44,11 @@ class Command(BaseCommand):
             help="Specific service to send certificates to (from config)",
         )
         parser.add_argument(
+            "--certificate-id",
+            type=int,
+            help="Process only the certificate with this specific ID",
+        )
+        parser.add_argument(
             "--days",
             type=int,
             help="Number of days of certificates to process",

--- a/nau_openedx_extensions/coursecertificate/tests/fixtures.py
+++ b/nau_openedx_extensions/coursecertificate/tests/fixtures.py
@@ -23,6 +23,7 @@ class User:
     """
 
     def __init__(self):
+        self.id = fake.random_int(1, 10000)
         self.username = f"user_{fake.random_int(1, 10000)}"
         self.email = f"{self.username}@example.com"
         self.profile = Profile(f"{fake.first_name()} {fake.last_name()}")
@@ -63,6 +64,7 @@ class Certificate:
     """
 
     def __init__(self, user: User):
+        self.id = fake.random_int(1, 10000)
         self.user = user
         self.course_id = CourseKey.from_string(f"course-v1:edX+Demo{fake.random_int(1, 100)}+Course")
         self.verify_uuid = fake.uuid4()

--- a/nau_openedx_extensions/coursecertificate/tests/test_commands.py
+++ b/nau_openedx_extensions/coursecertificate/tests/test_commands.py
@@ -307,6 +307,97 @@ class TestSendCertificatesByWebServiceCommand(TestCase):
 
             self.assertIn("Service 'nonexistent_service' not found", str(context.exception))
 
+    @patch("builtins.open", mock_open())
+    def test_handle_with_certificate_id(self):
+        """Test command execution with specific certificate ID."""
+        config_yaml = yaml.dump(self.sample_config)
+
+        with patch("builtins.open", mock_open(read_data=config_yaml)):
+            with patch.object(self.command, "process_service_safely", return_value=True) as mock_process:
+                options = {
+                    "config": "/fake/path/config.yml",
+                    "certificate_id": 123,
+                    "dry_run": False,
+                    "async_mode": False,
+                }
+
+                self.command.handle(**options)
+
+                self.assertEqual(mock_process.call_count, 2)
+                call_args = mock_process.call_args
+                options_passed = call_args[0][1]
+                self.assertEqual(options_passed.get("certificate_id"), 123)
+
+    @patch("builtins.open", mock_open())
+    def test_handle_with_certificate_id_and_service_name(self):
+        """Test command execution with both certificate ID and service name."""
+        config_yaml = yaml.dump(self.sample_config)
+
+        with patch("builtins.open", mock_open(read_data=config_yaml)):
+            with patch.object(self.command, "process_service_safely", return_value=True) as mock_process:
+                options = {
+                    "config": "/fake/path/config.yml",
+                    "certificate_id": 456,
+                    "service_name": "test_service",
+                    "dry_run": False,
+                    "async_mode": False,
+                }
+
+                self.command.handle(**options)
+
+                mock_process.assert_called_once()
+                call_args = mock_process.call_args
+                options_passed = call_args[0][1]
+                self.assertEqual(options_passed.get("certificate_id"), 456)
+                self.assertEqual(options_passed.get("service_name"), "test_service")
+
+    @patch("builtins.open", mock_open())
+    def test_handle_with_certificate_id_and_dry_run(self):
+        """Test command execution with certificate ID in dry run mode."""
+        config_yaml = yaml.dump(self.sample_config)
+
+        with patch("builtins.open", mock_open(read_data=config_yaml)):
+            with patch.object(self.command, "process_service_safely", return_value=True) as mock_process:
+                options = {
+                    "config": "/fake/path/config.yml",
+                    "certificate_id": 789,
+                    "dry_run": True,
+                    "async_mode": False,
+                }
+
+                self.command.handle(**options)
+
+                self.assertEqual(mock_process.call_count, 2)
+                call_args = mock_process.call_args
+                options_passed = call_args[0][1]
+                self.assertEqual(options_passed.get("certificate_id"), 789)
+                self.assertTrue(options_passed.get("dry_run", False))
+
+                output = self.command.stdout.getvalue()
+                self.assertIn("=== DRY RUN MODE - No actual requests will be sent ===", output)
+
+    def test_process_service_safely_with_certificate_id(self):
+        """Test processing service safely with certificate ID option."""
+        service_config = {
+            "service_name": "test_service",
+            "endpoint_url": "https://api.test.com/certificates",
+        }
+
+        options = {"days": 7, "page_size": 100, "certificate_id": 999}
+
+        with patch.object(self.command.engine, "process_service") as mock_process:
+            result = self.command.process_service_safely(service_config, options)
+
+            self.assertTrue(result)
+            mock_process.assert_called_once_with(service_config, options)
+
+            call_args = mock_process.call_args
+            options_passed = call_args[0][1]
+            self.assertEqual(options_passed.get("certificate_id"), 999)
+
+            output = self.command.stdout.getvalue()
+            self.assertIn("Successfully processed service: test_service", output)
+
     def test_handle_sync_success(self):
         """Test successful sync handle execution."""
         config_yaml = yaml.dump(self.sample_config)
@@ -344,9 +435,32 @@ class TestSendCertificatesByWebServiceCommand(TestCase):
 
                     mock_load_config.assert_called_once_with("/fake/path/config.yml")
                     self.assertEqual(mock_process.call_count, 2)
-
                     output = self.command.stdout.getvalue()
                     self.assertIn("Successfully processed 0/2 services", output)
+
+    def test_handle_sync_with_certificate_id(self):
+        """Test sync handle execution with certificate ID."""
+        config_yaml = yaml.dump(self.sample_config)
+
+        with patch("builtins.open", mock_open(read_data=config_yaml)):
+            with patch.object(
+                self.command, "load_config", return_value=self.sample_config["NAU_SEND_COURSE_CERTIFICATE_CONFIG"]
+            ) as mock_load_config:
+                with patch.object(self.command, "process_service_safely", return_value=True) as mock_process:
+                    options = {
+                        "config": "/fake/path/config.yml",
+                        "certificate_id": 1234,
+                        "dry_run": False,
+                    }
+
+                    self.command.handle_sync(options)
+
+                    mock_load_config.assert_called_once_with("/fake/path/config.yml")
+                    self.assertEqual(mock_process.call_count, 2)
+
+                    call_args = mock_process.call_args
+                    options_passed = call_args[0][1]
+                    self.assertEqual(options_passed.get("certificate_id"), 1234)
 
     def test_load_config_with_endpoint_timeout(self):
         """Test loading configuration with endpoint_timeout setting."""
@@ -432,10 +546,7 @@ class TestSendCertificatesByWebServiceCommand(TestCase):
         config_yaml = yaml.dump(self.sample_config)
 
         with patch("builtins.open", mock_open(read_data=config_yaml)):
-            self.command.handle_async({
-                "config": "/fake/path/config.yml",
-                "service_name": "test_service"
-            })
+            self.command.handle_async({"config": "/fake/path/config.yml", "service_name": "test_service"})
 
         self.assertEqual(mock_task.delay.call_count, 1)
         args, kwargs = mock_task.delay.call_args
@@ -463,10 +574,7 @@ class TestSendCertificatesByWebServiceCommand(TestCase):
     def test_handle_async_partial_failure(self, mock_task):
         """Test async mode when some dispatches fail."""
 
-        mock_task.delay.side_effect = [
-            Mock(id="task-success"),
-            ValueError("Invalid config")
-        ]
+        mock_task.delay.side_effect = [Mock(id="task-success"), ValueError("Invalid config")]
         config_yaml = yaml.dump(self.sample_config)
 
         with patch("builtins.open", mock_open(read_data=config_yaml)):
@@ -484,10 +592,7 @@ class TestSendCertificatesByWebServiceCommand(TestCase):
 
         with patch("builtins.open", mock_open(read_data=config_yaml)):
             with self.assertRaises(CommandError) as context:
-                self.command.handle_async({
-                    "config": "/fake/path/config.yml",
-                    "service_name": "nonexistent_service"
-                })
+                self.command.handle_async({"config": "/fake/path/config.yml", "service_name": "nonexistent_service"})
 
         self.assertIn("Service 'nonexistent_service' not found", str(context.exception))
 
@@ -564,6 +669,23 @@ class TestSendCertificatesByWebServiceCommand(TestCase):
         output = self.command.stdout.getvalue()
         self.assertIn("Task dispatched for service 'unknown'", output)
 
+    def test_integration_with_certificate_id(self):
+        """Test integration passes certificate_id to engine."""
+        service_config = {
+            "service_name": "test_service",
+            "endpoint_url": "https://api.test.com/certificates",
+        }
+        options = {"days": 7, "page_size": 100, "certificate_id": 555}
+
+        with patch.object(self.command.engine, "process_service") as mock_process:
+            self.command.process_service_safely(service_config, options)
+
+            mock_process.assert_called_once_with(service_config, options)
+            # Verify that the options with certificate_id were passed
+            call_args = mock_process.call_args
+            passed_options = call_args[0][1]
+            self.assertEqual(passed_options["certificate_id"], 555)
+
 
 class TestSendCertificatesByWebServiceCommandIntegration(TestCase):
     """
@@ -574,28 +696,11 @@ class TestSendCertificatesByWebServiceCommandIntegration(TestCase):
         """Set up test data."""
         self.user = User()
         self.certificate = Certificate(self.user)
+        self.command = Command()
+        self.command.stdout = OutputWrapper(StringIO())
+        self.command.stderr = OutputWrapper(StringIO())
+
         self.sample_config = {
-            "NAU_SEND_COURSE_CERTIFICATE_CONFIG": [
-                {
-                    "service_name": "integration_test",
-                    "endpoint_url": "https://integration.example.com/api/test",
-                    "endpoint_timeout": 60,
-                    "auth_token": "integration_token",
-                    "auth_type": "bearer",
-                    "days": 14,
-                    "page_size": 200,
-                    "fields": [],
-                    "filters": []
-                }
-            ]
-        }
-
-    @patch.object(Command, "process_service_safely")
-    def test_full_command_execution(self, mock_process_service_safely: Mock):
-        """Test full command execution with real configuration."""
-        mock_process_service_safely.return_value = True
-
-        config = {
             "NAU_SEND_COURSE_CERTIFICATE_CONFIG": [
                 {
                     "service_name": "integration_test",
@@ -619,13 +724,17 @@ class TestSendCertificatesByWebServiceCommandIntegration(TestCase):
             ]
         }
 
+    @patch.object(Command, "process_service_safely")
+    def test_full_command_execution(self, mock_process_service_safely: Mock):
+        """Test full command execution with real configuration."""
+        mock_process_service_safely.return_value = True
+
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp_config_file:
-            yaml.dump(config, tmp_config_file)
+            yaml.dump(self.sample_config, tmp_config_file)
             config_path = tmp_config_file.name
 
         try:
-            command = Command()
-            command.handle(
+            self.command.handle(
                 config=config_path,
                 service_name="integration_test",
                 dry_run=False,
@@ -650,15 +759,12 @@ class TestSendCertificatesByWebServiceCommandIntegration(TestCase):
 
         mock_task.delay.return_value = Mock(id="integration-task")
         config_yaml = yaml.dump(self.sample_config)
-        command = Command()
-        command.stdout = OutputWrapper(StringIO())
 
         with patch("builtins.open", mock_open(read_data=config_yaml)):
-
-            command.handle(async_mode=True, config="/fake/path/config.yml")
+            self.command.handle(async_mode=True, config="/fake/path/config.yml")
 
             mock_task.delay.assert_called_once()
-            output = command.stdout.getvalue()
+            output = self.command.stdout.getvalue()
             self.assertIn("ASYNC MODE", output)
             self.assertIn("integration-task", output)
 
@@ -668,18 +774,15 @@ class TestSendCertificatesByWebServiceCommandIntegration(TestCase):
 
         mock_task.delay.return_value = Mock(id="dry-run-task")
         config_yaml = yaml.dump(self.sample_config)
-        command = Command()
-        command.stdout = OutputWrapper(StringIO())
 
         with patch("builtins.open", mock_open(read_data=config_yaml)):
-
-            command.handle(async_mode=True, dry_run=True, config="/fake/path/config.yml")
+            self.command.handle(async_mode=True, dry_run=True, config="/fake/path/config.yml")
 
             mock_task.delay.assert_called_once()
             args, kwargs = mock_task.delay.call_args
             self.assertTrue(args[1]["dry_run"])
 
-            output = command.stdout.getvalue()
+            output = self.command.stdout.getvalue()
             self.assertIn("ASYNC MODE", output)
             self.assertIn("DRY RUN MODE", output)
 
@@ -689,13 +792,41 @@ class TestSendCertificatesByWebServiceCommandIntegration(TestCase):
 
         mock_task.delay.return_value = Mock(id="filtered-task")
         config_yaml = yaml.dump(self.sample_config)
-        command = Command()
-        command.stdout = OutputWrapper(StringIO())
 
         with patch("builtins.open", mock_open(read_data=config_yaml)):
-
-            command.handle(async_mode=True, service_name="integration_test", config="/fake/path/config.yml")
+            self.command.handle(async_mode=True, service_name="integration_test", config="/fake/path/config.yml")
 
             mock_task.delay.assert_called_once()
             args, kwargs = mock_task.delay.call_args
             self.assertEqual(args[0]["service_name"], "integration_test")
+
+    @patch.object(Command, "process_service_safely")
+    def test_full_command_execution_with_certificate_id(self, mock_process_service_safely: Mock):
+        """Test full command execution with certificate ID."""
+        mock_process_service_safely.return_value = True
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp_config_file:
+            yaml.dump(self.sample_config, tmp_config_file)
+            config_path = tmp_config_file.name
+
+        try:
+            self.command.handle(
+                config=config_path,
+                service_name="integration_test",
+                certificate_id=777,
+                dry_run=True,
+                verbosity=0,
+            )
+        finally:
+            os.remove(config_path)
+
+        mock_process_service_safely.assert_called_once()
+        call_args = mock_process_service_safely.call_args
+        service_config = call_args[0][0]
+        options = call_args[0][1]
+
+        self.assertEqual(service_config["service_name"], "integration_test")
+        self.assertEqual(service_config["endpoint_url"], "https://api.test.com/certificates")
+        self.assertEqual(service_config["endpoint_timeout"], 90)
+        self.assertEqual(options["certificate_id"], 777)
+        self.assertEqual(options["dry_run"], True)

--- a/nau_openedx_extensions/coursecertificate/tests/test_engine.py
+++ b/nau_openedx_extensions/coursecertificate/tests/test_engine.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 from ddt import data, ddt
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
+from requests import RequestException
 
 from nau_openedx_extensions.coursecertificate.engine import CertificateEngine
 from nau_openedx_extensions.coursecertificate.tests.fixtures import Certificate, User
@@ -111,7 +112,21 @@ class TestCertificateEngine(TestCase):
 
         self.assertEqual(result, "test@example.com")
 
-    def test_extract_field_value_with_args(self):
+    def test_extract_field_value_with_args_str(self):
+        """Test field value extraction with arguments."""
+        field_config = {
+            "name": "test_field",
+            "func": "nau_openedx_extensions.coursecertificate.extractors.student_nau_user_extended_model_field",
+            "args": "nif",
+        }
+
+        certificate = Mock()
+        certificate.user.nauuserextendedmodel.nif = "123456789"
+        result = self.engine.extract_field_value(certificate, field_config)
+
+        self.assertEqual(result, "123456789")
+
+    def test_extract_field_value_with_args_list(self):
         """Test field value extraction with arguments."""
         field_config = {
             "name": "test_field",
@@ -463,9 +478,39 @@ class TestCertificateEngine(TestCase):
         mock_queryset = Mock()
         mock_use_read_replica.return_value = mock_queryset
 
-        result = self.engine.get_certificates_queryset(7)
+        result = self.engine.get_certificates_queryset(7, None)
 
         self.assertEqual(result, mock_queryset)
+        mock_use_read_replica.assert_called_once()
+        mock_certificate_model.objects.filter.assert_called_once()
+
+    @patch(f"{ENGINE_MODULE_PATH}.GeneratedCertificate")
+    @patch(f"{ENGINE_MODULE_PATH}.use_read_replica_if_available")
+    def test_get_certificates_queryset_with_certificate_id(
+        self, mock_use_read_replica: Mock, mock_certificate_model: Mock
+    ):
+        """Test getting certificates queryset with certificate ID."""
+        mock_queryset = Mock()
+        mock_use_read_replica.return_value = mock_queryset
+
+        result = self.engine.get_certificates_queryset(7, 1)
+
+        self.assertEqual(result, mock_queryset)
+        mock_use_read_replica.assert_called_once()
+        mock_certificate_model.objects.filter.assert_called_once()
+
+    @patch(f"{ENGINE_MODULE_PATH}.GeneratedCertificate")
+    @patch(f"{ENGINE_MODULE_PATH}.use_read_replica_if_available")
+    def test_get_certificates_queryset_with_certificate_id_not_found(
+        self, mock_use_read_replica: Mock, mock_certificate_model: Mock
+    ):
+        """Test getting certificates queryset with certificate ID not found."""
+        mock_use_read_replica.return_value = Mock(exists=Mock(return_value=False))
+        mock_certificate_model.objects.none.return_value = None
+
+        result = self.engine.get_certificates_queryset(7, 1)
+
+        self.assertIsNone(result)
         mock_use_read_replica.assert_called_once()
         mock_certificate_model.objects.filter.assert_called_once()
 
@@ -687,6 +732,24 @@ class TestCertificateEngine(TestCase):
             self.assertTrue(result)
             mock_send.assert_called_once()
 
+    @patch.object(CertificateEngine, "convert_certificates_to_service_format")
+    @patch.object(CertificateEngine, "send_certificates_to_service")
+    def test_process_certificates_page_with_no_data(
+        self, mock_send_certificates: Mock, mock_convert_certificates: Mock
+    ):
+        """Test processing certificates page with no data."""
+        service_config = {
+            "service_name": "test_service",
+            "endpoint_url": "https://api.test.com/certificates",
+        }
+        mock_convert_certificates.return_value = []
+
+        result = self.engine._process_certificates_page(self.certificates, service_config, dry_run=False)
+
+        self.assertTrue(result)
+        mock_convert_certificates.assert_called_once()
+        mock_send_certificates.assert_not_called()
+
     def test_process_certificates_pages(self):
         """Test processing certificates in pages."""
         service_config = {
@@ -711,6 +774,37 @@ class TestCertificateEngine(TestCase):
             # Should be called twice (one for each certificate)
             self.assertEqual(mock_process_page.call_count, 2)
 
+    def test_process_certificates_pages_failure(self):
+        """Test processing certificates pages with failure."""
+        service_config = {
+            "service_name": "test_service",
+            "endpoint_url": "https://api.test.com/certificates",
+        }
+        params = {
+            "page_size": 1,
+            "dry_run": False,
+        }
+
+        log_output = []
+
+        def mock_log(msg):
+            log_output.append(msg)
+
+        self.engine.log = mock_log
+
+        with patch.object(self.engine, "_process_certificates_page") as mock_process_page:
+            mock_process_page.side_effect = [True, False]
+
+            self.engine._process_certificates_pages(self.certificates, service_config, params)
+
+            self.assertEqual(mock_process_page.call_count, 2)
+
+            self.assertEqual(len(log_output), 4)
+            self.assertEqual(log_output[0], "Total certificates to process: 2")
+            self.assertEqual(log_output[1], "Processing 1 of 2 certificates (page 1)")
+            self.assertEqual(log_output[2], "Processing 2 of 2 certificates (page 2)")
+            self.assertEqual(log_output[3], "Failed to send page 2 to test_service")
+
     @patch.object(CertificateEngine, "get_certificates_queryset")
     def test_process_service_success(self, mock_get_queryset: Mock):
         """Test successful processing of a service."""
@@ -728,7 +822,22 @@ class TestCertificateEngine(TestCase):
         with patch.object(self.engine, "_process_certificates_pages") as mock_process_pages:
             self.engine.process_service(service_config, options)
 
-            mock_get_queryset.assert_called_once_with(7)
+            mock_get_queryset.assert_called_once_with(7, None)
+            mock_process_pages.assert_called_once()
+
+    @patch.object(CertificateEngine, "get_certificates_queryset")
+    def test_process_service_with_certificate_id(self, mock_get_queryset: Mock):
+        """Test processing service with certificate ID."""
+        service_config = {
+            "service_name": "test_service",
+            "endpoint_url": "https://api.test.com/certificates",
+        }
+        options = {"certificate_id": 1}
+
+        with patch.object(self.engine, "_process_certificates_pages") as mock_process_pages:
+            self.engine.process_service(service_config, options)
+
+            mock_get_queryset.assert_called_once_with(7, 1)
             mock_process_pages.assert_called_once()
 
     @patch.object(CertificateEngine, "get_certificates_queryset")
@@ -744,7 +853,7 @@ class TestCertificateEngine(TestCase):
         with patch.object(self.engine, "_process_certificates_pages") as mock_process_pages:
             self.engine.process_service(service_config, options)
 
-            mock_get_queryset.assert_called_once_with(7)
+            mock_get_queryset.assert_called_once_with(7, None)
             mock_process_pages.assert_called_once()
 
     def test_log_dry_run_info(self):
@@ -871,12 +980,11 @@ class TestCertificateEngine(TestCase):
         timeout = 60
 
         with patch("requests.post") as mock_post:
-            mock_post.side_effect = Exception("Connection error")
+            mock_post.side_effect = RequestException("Request error")
 
-            with self.assertRaises(Exception) as context:
-                self.engine._send_http_request(api_url, headers, certificates_data, timeout)
+            result = self.engine._send_http_request(api_url, headers, certificates_data, timeout)
 
-            self.assertEqual(str(context.exception), "Connection error")
+            self.assertFalse(result)
 
     def test_engine_initialization_with_logger(self):
         """Test engine initialization with custom logger."""

--- a/nau_openedx_extensions/coursecertificate/tests/test_handlers.py
+++ b/nau_openedx_extensions/coursecertificate/tests/test_handlers.py
@@ -1,0 +1,137 @@
+"""
+Unit tests for coursecertificate handlers.
+"""
+
+from unittest.mock import Mock, patch
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.test import TestCase
+from openedx_events.data import EventsMetadata
+from openedx_events.learning.data import CertificateData, CourseData, UserData, UserPersonalData
+from openedx_events.learning.signals import CERTIFICATE_CREATED
+
+from nau_openedx_extensions.coursecertificate.handlers import certificate_created_send_to_external_services_handler
+from nau_openedx_extensions.coursecertificate.tests.fixtures import Certificate, User
+
+
+class TestCertificateCreatedHandler(TestCase):
+    """
+    Tests for the certificate_created_send_to_external_services_handler.
+    """
+
+    def setUp(self):
+        """Set up test data."""
+        self.user = User()
+        self.certificate = Certificate(self.user)
+
+        self.user_data = UserData(
+            pii=UserPersonalData(
+                username=self.user.username,
+                email=self.user.email,
+                name=self.user.profile.name,
+            ),
+            id=self.user.id,
+            is_active=True,
+        )
+
+        self.course_data = CourseData(
+            course_key=self.certificate.course_id,
+            display_name=self.certificate.course_id.course,
+            start=None,
+            end=None,
+        )
+
+        self.certificate_data = CertificateData(
+            user=self.user_data,
+            course=self.course_data,
+            mode=self.certificate.mode,
+            grade=self.certificate.grade,
+            download_url=f"https://lms.example.com/certificates/{self.certificate.verify_uuid}",
+            name=self.certificate.name,
+            current_status=self.certificate.status,
+            previous_status=None,
+        )
+
+        self.metadata = EventsMetadata(
+            event_type="org.openedx.learning.certificate.created.v1",
+            minorversion=0,
+        )
+
+    @patch("nau_openedx_extensions.coursecertificate.handlers.log")
+    @patch("nau_openedx_extensions.coursecertificate.handlers.call_command")
+    @patch("nau_openedx_extensions.coursecertificate.handlers.GeneratedCertificate")
+    def test_certificate_created_handler_success(
+        self, mock_certificate_model: Mock, mock_call_command: Mock, mock_log: Mock
+    ):
+        """
+        Test successful execution of certificate created handler.
+
+        Expected behavior:
+        - Handler retrieves the GeneratedCertificate from database using user_id and course_id
+        - Handler logs info message about sending certificate to external services
+        - Handler calls the send_certificates_by_web_service command with certificate_id
+        """
+        mock_certificate_model.objects.get.return_value = self.certificate
+
+        CERTIFICATE_CREATED.connect(certificate_created_send_to_external_services_handler)
+        CERTIFICATE_CREATED.send_event(certificate=self.certificate_data)
+
+        mock_certificate_model.objects.get.assert_called_once_with(
+            user_id=self.user.id, course_id=self.certificate.course_id
+        )
+        mock_call_command.assert_called_once_with(
+            "send_certificates_by_web_service", certificate_id=self.certificate.id, async_mode=True
+        )
+        mock_log.info.assert_called_once_with(f"Sending certificate {self.certificate.id} to external services")
+
+    @patch("nau_openedx_extensions.coursecertificate.handlers.log")
+    @patch("nau_openedx_extensions.coursecertificate.handlers.call_command")
+    @patch("nau_openedx_extensions.coursecertificate.handlers.GeneratedCertificate")
+    def test_certificate_created_handler_certificate_not_found(
+        self, mock_certificate_model: Mock, mock_call_command: Mock, mock_log: Mock
+    ):
+        """
+        Test handler behavior when certificate is not found in database.
+
+        Expected behavior:
+        - Handler logs an error when certificate doesn't exist
+        - Handler returns early without calling the command
+        - Command should not be called
+        """
+        mock_certificate_model.DoesNotExist = ObjectDoesNotExist
+        mock_certificate_model.objects.get.side_effect = mock_certificate_model.DoesNotExist("Certificate not found")
+
+        CERTIFICATE_CREATED.connect(certificate_created_send_to_external_services_handler)
+        CERTIFICATE_CREATED.send_event(certificate=self.certificate_data)
+
+        mock_call_command.assert_not_called()
+        mock_log.error.assert_called_once_with(
+            f"No GeneratedCertificate found for user_id={self.user.id} and course_id={self.certificate.course_id}"
+        )
+
+    @patch("nau_openedx_extensions.coursecertificate.handlers.log")
+    @patch("nau_openedx_extensions.coursecertificate.handlers.call_command")
+    @patch("nau_openedx_extensions.coursecertificate.handlers.GeneratedCertificate")
+    def test_certificate_created_handler_command_failure(
+        self, mock_certificate_model: Mock, mock_call_command: Mock, mock_log: Mock
+    ):
+        """
+        Test handler behavior when the management command fails.
+
+        Expected behavior:
+        - Handler catches command exceptions and logs them
+        - Handler logs error with exception details
+        - Handler does not re-raise the exception
+        """
+        mock_certificate_model.objects.get.return_value = self.certificate
+        mock_call_command.side_effect = Exception("Command failed")
+
+        CERTIFICATE_CREATED.connect(certificate_created_send_to_external_services_handler)
+        CERTIFICATE_CREATED.send_event(certificate=self.certificate_data)
+
+        mock_call_command.assert_called_once_with(
+            "send_certificates_by_web_service", certificate_id=self.certificate.id, async_mode=True
+        )
+        mock_log.error.assert_called_once_with(
+            f"Failed to send certificate {self.certificate.id} to external services: Command failed", exc_info=True
+        )


### PR DESCRIPTION
## Description

This PR adds an event listener when the `CERTIFICATE_CREATED` event is sent in the platform. The command was also updated to receive a new parameter called `certificate-id`.

Each time a new certificate is created, in the background, a task is executed for each service configured in the `config.yml` file with the requested data of the new certificate.

Additionally, unit tests were included to validate the event listener, the new parameter in the command, and the engine logic.

## Related Issues
- https://github.com/fccn/nau-technical/issues/555

## Usage

You can use the new parameter by running the `send_course_certificates_by_web_service` command:

```bash
python manage.py lms send_certificates_by_web_service --certificate-id <certificate-id>
```
e.g:

```bash
python manage.py lms send_certificates_by_web_service --certificate-id 100
```

## Testing Instructions

1. Create a `tutor local` environment in the Redwood version. You need to run `tutor local` to use the workers.
2. Create a mount of `edx-platform` using the [NAU fork](https://github.com/fccn/edx-platform).
3. Install this plugin with the changes included in this pull request.
4. Create a course, configure grading, and certificates.
5. With a user, complete the course and request your certificate.
6. Automatically, the event listener runs in the background the command with the ID of the newly created certificate.
7. The certificate data is sent to all configured services if applicable.