### PR TITLE
chore: apply_saml_overrides elimination

### DIFF
--- a/nau_openedx_extensions/settings/common.py
+++ b/nau_openedx_extensions/settings/common.py
@@ -51,8 +51,8 @@ def plugin_settings(settings):
     settings.NAU_ADD_SAML_IDP_CLASSES = (
         "nau_openedx_extensions.third_party_auth.providers.saml.extend_saml_idp_classes"
     )
-    settings.NAU_APPLY_SAML_OVERRIDES = (
-        "nau_openedx_extensions.third_party_auth.providers.saml._apply_saml_overrides"
+    settings.NAU_CERTIFICATE_CONTEXT_EXTENSION = (
+        "nau_openedx_extensions.certificates.context_extender.update_cert_context"
     )
     settings.NAU_STUDENT_ACCOUNT_CONTEXT_EXTENSION = "nau_openedx_extensions.custom_registration_form.context_extender.update_account_view"
     settings.NAU_STUDENT_SERIALIZER_CONTEXT_EXTENSION = "nau_openedx_extensions.custom_registration_form.context_extender.update_account_serializer"

--- a/nau_openedx_extensions/settings/production.py
+++ b/nau_openedx_extensions/settings/production.py
@@ -23,8 +23,10 @@ def plugin_settings(settings):
     settings.NAU_ADD_SAML_IDP_CLASSES = getattr(settings, "ENV_TOKENS", {}).get(
         "NAU_ADD_SAML_IDP_CLASSES", settings.NAU_ADD_SAML_IDP_CLASSES
     )
-    settings.NAU_APPLY_SAML_OVERRIDES = getattr(settings, "ENV_TOKENS", {}).get(
-        "NAU_APPLY_SAML_OVERRIDES", settings.NAU_APPLY_SAML_OVERRIDES
+    settings.NAU_CERTIFICATE_CONTEXT_EXTENSION = getattr(
+        settings, "ENV_TOKENS", {}
+    ).get(
+        "NAU_CERTIFICATE_CONTEXT_EXTENSION", settings.NAU_CERTIFICATE_CONTEXT_EXTENSION
     )
     settings.NAU_STUDENT_ACCOUNT_CONTEXT_EXTENSION = getattr(
         settings, "ENV_TOKENS", {}

--- a/nau_openedx_extensions/third_party_auth/providers/saml.py
+++ b/nau_openedx_extensions/third_party_auth/providers/saml.py
@@ -8,7 +8,7 @@ from importlib import import_module
 
 from django.conf import settings
 
-from nau_openedx_extensions.edxapp_wrapper.registration import EdXSAMLIdentityProvider, get_registration_extension_form
+from nau_openedx_extensions.edxapp_wrapper.registration import EdXSAMLIdentityProvider
 
 log = logging.getLogger(__name__)
 

--- a/nau_openedx_extensions/third_party_auth/providers/saml.py
+++ b/nau_openedx_extensions/third_party_auth/providers/saml.py
@@ -82,38 +82,3 @@ def extend_saml_idp_classes(*args, **kwargs):
             )
 
     return kwargs["choices"]
-
-
-def _apply_saml_overrides(*args, **kwargs):
-    """
-    Applies custom saml override rules for custom
-    registration forms
-    """
-    custom_form = get_registration_extension_form()
-
-    if not custom_form:
-        return
-
-    form_desc = kwargs["form_desc"]
-
-    for field_name, _field in custom_form.fields.items():
-        visibility = kwargs["extra_settings"].get(field_name, "hidden")
-        # applying commmon overrides
-        form_desc.override_field_properties(
-            field_name,
-            required=False,
-        )
-
-        if visibility == "required":
-            form_desc.override_field_properties(
-                field_name,
-                required=True,
-            )
-        if visibility == "hidden":
-            form_desc.override_field_properties(
-                field_name,
-                field_type=visibility,
-                label="",
-                instructions="",
-                restrictions={},
-            )


### PR DESCRIPTION
Related issue: https://github.com/fccn/nau-technical/issues/394
This PR is related with https://github.com/fccn/edx-platform/pull/28
## Summary
Remove the custom `NAU_APPLY_SAML_OVERRIDES` extension point from `_apply_third_party_auth_overrides` as it's now redundant with Open edX's native registration form extension mechanisms.

## Background
Previously, we used a custom extension point to apply field visibility and requirement overrides to custom registration form fields during SAML authentication. However, analysis of the Open edX code shows that this functionality is already provided natively:

This function:
https://github.com/fccn/edx-platform/blob/3c6945706504f975a227ee45a1fb017e9402dab1/openedx/core/djangoapps/user_authn/views/registration_form.py#L302 loads the [REGISTRATION_EXTENSION_FORM](https://github.com/fccn/nau-kubernetes-manifests/blob/6011681478922dd69c1c022f77a188f97c0c3435/production/environments/production/env/apps/openedx/settings/lms/production.py#L733-L734) that is settled by a setting.

And the visibility is managed [here](https://github.com/fccn/edx-platform/blob/3c6945706504f975a227ee45a1fb017e9402dab1/openedx/core/djangoapps/user_authn/views/registration_form.py#L420-L470), just like the extension have been doing it.

## Testing

I run this code directly in django shell to verify that REGISTRATION_EXTRA_FIELDS is actually updated based on the setting and its visibility:

```
# Quick test for NAU registration configuration
from django.conf import settings
from openedx.core.djangoapps.user_authn.views.registration_form import RegistrationFormFactory
from django.test import RequestFactory

#  Test REGISTRATION_EXTRA_FIELDS
if hasattr(settings, 'REGISTRATION_EXTRA_FIELDS'):
    extra_fields = settings.REGISTRATION_EXTRA_FIELDS
    print(f"✅ Extra fields configured: {len(extra_fields)} total")
    
    # Check NAU specific fields
    nau_fields = ['data_authorization', 'nif', 'allow_newsletter', 'employment_situation']
    print("NAU fields visibility:")
    for field in nau_fields:
        visibility = extra_fields.get(field, 'NOT CONFIGURED')
        status = "✅" if visibility != 'NOT CONFIGURED' else "❌"
        print(f"  {status} {field}: {visibility}")
else:
    print("ERROR: REGISTRATION_EXTRA_FIELDS: NOT CONFIGURED")

#  Test final form generation
try:
    factory = RequestFactory()
    request = factory.get('/register')
    request.session = {}
    
    form_factory = RegistrationFormFactory()
    form_desc = form_factory.get_registration_form(request)
    all_fields = [field['name'] for field in form_desc.fields]
    
    print(f"✅ Final form: {len(all_fields)} fields generated")
    
    # Check if NAU fields appear in final form
    nau_test_fields = ['data_authorization', 'allow_newsletter', 'employment_situation']
    print("NAU fields in final form:")
    for field_name in nau_test_fields:
        if field_name in all_fields:
            field_data = next((f for f in form_desc.fields if f['name'] == field_name), {})
            field_type = field_data.get('type', 'N/A')
            required = field_data.get('required', False)
            print(f"  ✅ {field_name}: {field_type} (required={required})")
        else:
            print(f"   {field_name}: NOT FOUND")
            
except Exception as e:
    print(f" Error generating form: {e}")

print("=== END TEST ===")
```

The output was:
<img width="421" height="257" alt="image" src="https://github.com/user-attachments/assets/c34090f6-a086-4a78-a867-e581da5eb508" />

That indicates that field names and visibility are successfully loaded, and the final form only shows required or optional fields.