### PR TITLE
fix: render certificate for anonymous user

### DIFF
--- a/nau_openedx_extensions/edxapp_wrapper/backends/certificates_r_v1.py
+++ b/nau_openedx_extensions/edxapp_wrapper/backends/certificates_r_v1.py
@@ -4,8 +4,4 @@ Real implementation of the certificate backend.
 
 # pylint: disable=import-error, unused-import
 from lms.djangoapps.certificates.models import CertificateHtmlViewConfiguration, GeneratedCertificate
-from lms.djangoapps.certificates.views.webview import (
-    _get_catalog_data_for_course,
-    _get_custom_template_and_language,
-    _get_user_certificate,
-)
+from lms.djangoapps.certificates.views.webview import _get_catalog_data_for_course, _get_custom_template_and_language

--- a/nau_openedx_extensions/edxapp_wrapper/certificates.py
+++ b/nau_openedx_extensions/edxapp_wrapper/certificates.py
@@ -43,14 +43,5 @@ def get_custom_template_and_language(*args, **kwargs):
     return backend._get_custom_template_and_language(*args, **kwargs)  # pylint: disable=protected-access
 
 
-def get_user_certificate(*args, **kwargs):
-    """
-    Wrapper for `lms.djangoapps.certificates.views.webview._get_user_certificate` in edx-platform.
-    """
-    backend_function = settings.NAU_CERTIFICATES_MODULE
-    backend = import_module(backend_function)
-    return backend._get_user_certificate(*args, **kwargs)  # pylint: disable=protected-access
-
-
 GeneratedCertificate = get_generated_certificate_class()
 CertificateHtmlViewConfiguration = get_certificate_html_view_configuration_class()

--- a/nau_openedx_extensions/filters/filter_certificates.py
+++ b/nau_openedx_extensions/filters/filter_certificates.py
@@ -28,7 +28,6 @@ from nau_openedx_extensions.edxapp_wrapper.certificates import (
     CertificateHtmlViewConfiguration,
     get_catalog_data_for_course,
     get_custom_template_and_language,
-    get_user_certificate,
 )
 from nau_openedx_extensions.edxapp_wrapper.course_module import get_course
 from nau_openedx_extensions.edxapp_wrapper.grades import get_course_grades
@@ -108,16 +107,16 @@ class FilterUpdateCertificateContext(PipelineStep):
                 - course: Course object
                 - course_key: Course key object
                 - nau_cert_settings: Custom certificate settings
-                - request: Current HTTP request
                 - user: User object
                 - user_certificate: Generated certificate for the user
         """
         course_key = CourseKey.from_string(context["course_id"])
         course = get_course(course_key)
-        request = get_current_request()
-        user = request.user  # type: ignore
-        preview_mode = request.GET.get("preview", None)  # type: ignore
-        user_certificate = get_user_certificate(request, user, course_key, course, preview_mode)
+        user_certificate = context["user_certificate"]
+        if getattr(user_certificate, "user", None):
+            user = user_certificate.user
+        else:
+            user = get_current_request().user
         certificate_language = self._determine_certificate_language(course, user_certificate, custom_template)
 
         return {
@@ -126,7 +125,6 @@ class FilterUpdateCertificateContext(PipelineStep):
             "course": course,
             "course_key": course_key,
             "nau_cert_settings": course.cert_html_view_overrides.get("nau_certs_settings"),
-            "request": request,
             "user": user,
             "user_certificate": user_certificate,
         }

--- a/nau_openedx_extensions/filters/tests/test_filter_certificates.py
+++ b/nau_openedx_extensions/filters/tests/test_filter_certificates.py
@@ -24,7 +24,6 @@ class FilterUpdateCertificateContextTest(TestCase):
 
     patch_get_course = patch(f"{FILTERS_PATH}.get_course")
     patch_get_request = patch(f"{FILTERS_PATH}.get_current_request")
-    patch_get_user_certificate = patch(f"{FILTERS_PATH}.get_user_certificate")
     patch_cert_config = patch(f"{FILTERS_PATH}.CertificateHtmlViewConfiguration")
     patch_translation = patch(f"{FILTERS_PATH}.translation")
     patch_get_catalog_data = patch(f"{FILTERS_PATH}.get_catalog_data_for_course")
@@ -38,27 +37,22 @@ class FilterUpdateCertificateContextTest(TestCase):
         self.course_id_str = "course-v1:Demo+DemoX+Demo_Course"
         self.course_key = CourseKey.from_string(self.course_id_str)
         self.user = MagicMock(username="testuser", email="test@example.com")
+        self.request_user = MagicMock(username="testuser2", email="test2@example.com")
         self.course = MagicMock(id=self.course_key, display_name="Test Course")
-        self.user_certificate = MagicMock(grade="85", mode="verified")
-        self.context = {"course_id": self.course_id_str}
-        self.request = MagicMock(user=self.user)
+        self.user_certificate = MagicMock(grade="85", mode="verified", user=self.user)
+        self.context = {"course_id": self.course_id_str, "user_certificate": self.user_certificate}
+        self.request = MagicMock(user=self.request_user)
 
     @patch_cert_config
-    @patch_get_user_certificate
-    @patch_get_request
     @patch_get_course
     def test_get_properties_basic(
         self,
         mock_get_course: Mock,
-        mock_get_request: Mock,
-        mock_get_user_certificate: Mock,
         mock_cert_config: Mock,
     ):
         with patch.object(self.filter, "_determine_certificate_language") as mock_determine_lang:
             self.course.cert_html_view_overrides = {"nau_certs_settings": {"setting": "value"}}
             mock_get_course.return_value = self.course
-            mock_get_request.return_value = self.request
-            mock_get_user_certificate.return_value = self.user_certificate
             mock_cert_config.get_config.return_value = {"config": "test"}
             mock_determine_lang.return_value = "en"
 
@@ -69,7 +63,6 @@ class FilterUpdateCertificateContextTest(TestCase):
             self.assertEqual(result["course"], self.course)
             self.assertEqual(result["course_key"], self.course_key)
             self.assertEqual(result["nau_cert_settings"], {"setting": "value"})
-            self.assertEqual(result["request"], self.request)
             self.assertEqual(result["user"], self.user)
             self.assertEqual(result["user_certificate"], self.user_certificate)
 
@@ -467,3 +460,34 @@ class FilterUpdateCertificateContextTest(TestCase):
 
         mock_log.error.assert_called_once()
         self.assertEqual(result, {})
+
+    @patch_get_request
+    @patch_cert_config
+    @patch_get_course
+    def test_get_properties_preview_certificate(
+        self,
+        mock_get_course: Mock,
+        mock_cert_config: Mock,
+        mock_get_request: Mock,
+    ):
+        """
+        Test _get_properties for preview certificate, current logged-in user is different from certificate user.
+        """
+        # Simulate preview certificate that is not saved/linked to user
+        self.user_certificate.user = None
+        with patch.object(self.filter, "_determine_certificate_language") as mock_determine_lang:
+            self.course.cert_html_view_overrides = {"nau_certs_settings": {"setting": "value"}}
+            mock_get_course.return_value = self.course
+            mock_cert_config.get_config.return_value = {"config": "test"}
+            mock_determine_lang.return_value = "en"
+            mock_get_request.return_value = self.request
+
+            result = self.filter._get_properties(self.context, None)
+
+            self.assertEqual(result["certificate_language"], "en")
+            self.assertEqual(result["configuration"], {"config": "test"})
+            self.assertEqual(result["course"], self.course)
+            self.assertEqual(result["course_key"], self.course_key)
+            self.assertEqual(result["nau_cert_settings"], {"setting": "value"})
+            self.assertEqual(result["user"], self.request_user)
+            self.assertEqual(result["user_certificate"], self.user_certificate)


### PR DESCRIPTION
Fix the render course certificate when being viewed by an anonymous user.
Add a test for previewing the certificate.

This assumes that the CertificateRenderStarted Open edX filter has the user_certificate on its context.

fccn/nau-technical#667