### PR TITLE
feat: add is_active to the admin filters

### DIFF
--- a/nau_openedx_extensions/custom_registration_form/admin.py
+++ b/nau_openedx_extensions/custom_registration_form/admin.py
@@ -26,8 +26,8 @@ class NauUserExtendedModelAdmin(admin.ModelAdmin, ExportCsvMixin):
         "openedx_email",
     )
     raw_id_fields = ("user",)
-    list_filter = ("allow_newsletter", "user__date_joined")
-    list_display = ("openedx_username", "openedx_email", "date_joined")
+    list_filter = ("allow_newsletter", "user__date_joined", "user__is_active",)
+    list_display = ("openedx_username", "openedx_email", "date_joined",)
 
     # use this user date_joined field has an hierarchy to the user can search the last registries more rapid.
     date_hierarchy = "user__date_joined"

--- a/nau_openedx_extensions/custom_registration_form/models.py
+++ b/nau_openedx_extensions/custom_registration_form/models.py
@@ -109,6 +109,9 @@ class NauUserExtendedModel(models.Model):
     def date_joined(self):
         return self.user.date_joined
 
+    def is_active(self):
+        return self.user.is_active
+
 # Add more fields to the student profile download csv file.
 #
 # This feature requires that additional properties be configured on `STUDENT_FEATURES` list on file


### PR DESCRIPTION
Add an option to filter by active users to avoid sending newsletter to users that have not finished the account activation process.

fccn/nau-technical#702