### PR TITLE
chore: constraints versions updated

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,9 +1,9 @@
 # Same version as the platform
 celery>=5.2.2,<6.0.0
 Django<5.0
-edx-opaque-keys[django]==2.9.0
-openedx-filters==1.12.0
-openedx-events==9.15.0
+edx-opaque-keys[django]==3.0.0
+openedx-filters==2.0.1
+openedx-events==10.2.0
 # pip-tools==7.4.1
 click>=8.0,<9.0
 pylint<2.16.0


### PR DESCRIPTION
This PR updated this 3 requirements to fit the teak versions:

edx-opaque-keys[django]==3.0.0
openedx-filters==2.0.1
openedx-events==10.2.0