### PR TITLE
fix: adjusted PartnerAPIClient on admin

### DIFF
--- a/nau_openedx_extensions/partner_integration/admin.py
+++ b/nau_openedx_extensions/partner_integration/admin.py
@@ -1,61 +1,80 @@
 """Admin implementation for PartnerAPIClient"""
+import json
+import uuid
+
+from django import forms
 from django.contrib import admin
+from django.contrib.auth.hashers import make_password
+from django.utils.crypto import get_random_string
 from django.utils.html import format_html
 
 from .models import PartnerAPIClient
 
 
-@admin.register(PartnerAPIClient)
-class PartnerAPIClientAdmin(admin.ModelAdmin):
-    """
-    Admin interface for PartnerAPIClient, allows managing API clients.
-    """
-    list_display = (
-        "id",
-        "name",
-        "client_id",
-        "is_active",
-        "is_staff",
-        "created_at",
-        "updated_at",
-        "preview_security_scope",
+class PartnerAPIClientForm(forms.ModelForm):
+    """Admin form for better manage PartnerAPIClient registers"""
+    query_security_scope = forms.JSONField(
+        required=False,
+        widget=forms.Textarea(attrs={
+            "rows": 10,
+            "cols": 80,
+            "placeholder": json.dumps({
+                "base_security_scope": {
+                    "org": "FCCN",
+                },
+                "base_certificates_scope": {
+                    "created_date__gte": "2024-06-01",
+                    "user_nauuserextendedmodel__nif__isnull": False,
+                    "user_nauuserextendedmodel__cc_nif__isnull": False
+                }
+            }, indent=2)
+        })
     )
 
-    list_filter = ("is_active", "is_staff", "created_at")
-    search_fields = ("name", "client_id")
-    readonly_fields = ("client_id", "password", "created_at", "updated_at")
+    class Meta:
+        model = PartnerAPIClient
+        fields = "__all__"
+
+
+@admin.register(PartnerAPIClient)
+class PartnerAPIClientAdmin(admin.ModelAdmin):
+    """Admin registration for PartnerAPIClient model"""
+    form = PartnerAPIClientForm
+    list_display = ('name', 'client_id', 'is_active', 'is_staff', 'created_at', 'updated_at')
+    readonly_fields = ('client_id', 'created_at', 'updated_at', 'credentials_preview')
 
     fieldsets = (
         (None, {
-            "fields": (
-                "name",
-                "client_id",
-                "password",
-                "is_active",
-                "is_staff",
-                "query_security_scope",
-            )
+            'fields': ('name', 'credentials_preview', 'is_active', 'is_staff', 'query_security_scope')
         }),
-        ("Timestamps", {"fields": ("created_at", "updated_at")}),
-        ("Permissions", {
-            "classes": ("collapse",),
-            "fields": (
-                "groups",
-                "user_permissions",
-            )
+        ('Timestamps', {
+            'fields': ('created_at', 'updated_at'),
+        }),
+        ('Permissions', {
+            'fields': ('groups', 'user_permissions'),
         }),
     )
 
-    def preview_security_scope(self, obj):
+    def credentials_preview(self, obj):
         """
-        Small human-readable preview of the security scope JSON.
+        Display a one-time raw password and UUID for new objects.
         """
-        if not obj.query_security_scope:
-            return "-"
+        if not obj.pk:
+            self._raw_password = get_random_string(64)  # pylint: disable=attribute-defined-outside-init
+            self._uuid = uuid.uuid4()  # pylint: disable=attribute-defined-outside-init
+            return format_html(
+                "<b>Client ID:</b> {}<br><b>Password:</b> {} (copy these before saving!)",
+                self._uuid, self._raw_password
+            )
+        return format_html("<i>Already saved — password hidden</i>")
 
-        text = str(obj.query_security_scope)
-        preview = text[:80] + ("..." if len(text) > 80 else "")
+    credentials_preview.short_description = "Credentials"
 
-        return format_html("<code>{}</code>", preview)
-
-    preview_security_scope.short_description = "Security Scope"
+    def save_model(self, request, obj, form, change):
+        """
+        Assign `client_id` and `password` for new objects.
+        """
+        if not obj.pk:
+            obj.client_id = self._uuid
+            obj.password = make_password(self._raw_password)
+        super().save_model(request, obj, form, change)

--- a/nau_openedx_extensions/partner_integration/models.py
+++ b/nau_openedx_extensions/partner_integration/models.py
@@ -3,7 +3,6 @@
 import logging
 import uuid
 
-from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
 from django.db import models
 from django.utils.crypto import get_random_string
@@ -71,11 +70,8 @@ class PartnerAPIClient(AbstractBaseUser, PermissionsMixin):
 
     def save(self, *args, **kwargs):
         """
-        Override save to generate secure password for new PartnerAPIClient instances.
+        Override save to validate basis for new PartnerAPIClient instances.
         """
-        if not self.pk:
-            raw_secret = get_random_string(64)
-            self.password = make_password(raw_secret)
         self.validate_basis(self.query_security_scope)
         super().save(*args, **kwargs)
 


### PR DESCRIPTION
The default values pre-filled in the admin form get override when creating a new register. It makes never possible to obtain the password, as after saving it generates a new password and hashes it.

related to: https://github.com/fccn/nau-technical/issues/674