### PR TITLE
feat: changed partner-integration admin to have secret

### DIFF
--- a/nau_openedx_extensions/partner_integration/admin.py
+++ b/nau_openedx_extensions/partner_integration/admin.py
@@ -3,15 +3,19 @@ import json
 
 from django import forms
 from django.contrib import admin
-from django.contrib.auth.hashers import make_password
 from django.utils.crypto import get_random_string
-from django.utils.html import format_html
 
 from .models import PartnerAPIClient
 
 
 class PartnerAPIClientForm(forms.ModelForm):
     """Admin form for better manage PartnerAPIClient registers"""
+    password = forms.CharField(
+        required=True,
+        label="Secret",
+        help_text="The password field of PartnerAPIClient model",
+        widget=forms.TextInput(attrs={"size": 80})
+    )
     query_security_scope = forms.JSONField(
         required=False,
         help_text="Enter a valid JSON object. Example: {\"base_security_scope\": {\"org\": \"NAU\"}}",
@@ -41,11 +45,11 @@ class PartnerAPIClientAdmin(admin.ModelAdmin):
     """Admin registration for PartnerAPIClient model"""
     form = PartnerAPIClientForm
     list_display = ('name', 'client_id', 'is_active', 'is_staff', 'created_at', 'updated_at')
-    readonly_fields = ('client_id', 'created_at', 'updated_at', 'credentials_preview')
+    readonly_fields = ('client_id', 'created_at', 'updated_at')
 
     fieldsets = (
         (None, {
-            'fields': ('name', 'credentials_preview', 'is_active', 'is_staff', 'query_security_scope')
+            'fields': ('name', 'password', 'is_active', 'is_staff', 'query_security_scope')
         }),
         ('Timestamps', {
             'fields': ('created_at', 'updated_at'),
@@ -55,24 +59,8 @@ class PartnerAPIClientAdmin(admin.ModelAdmin):
         }),
     )
 
-    def credentials_preview(self, obj):
-        """
-        Display a one-time raw password and UUID for new objects.
-        """
-        if not obj.pk:
-            obj.password = get_random_string(64)  # pylint: disable=attribute-defined-outside-init
-            return format_html(
-                "<b>Secret:</b> {}<br><b>Copy before saving!</b>",
-                obj.password
-            )
-        return format_html("<b>Client ID:</b> {}<br><b>Secret:</b> <i>Already saved, it's hidden</i>", obj.client_id)
-
-    credentials_preview.short_description = "Secret"
-
-    def save_model(self, request, obj, form, change):
-        """
-        Assign `client_id` and `password` for new objects.
-        """
-        if not obj.pk:
-            obj.password = make_password(obj.password)
-        super().save_model(request, obj, form, change)
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        current_form = super().get_form(request, obj, **kwargs)
+        if not obj:
+            current_form.base_fields["password"].initial = get_random_string(64)
+        return current_form

--- a/nau_openedx_extensions/partner_integration/models.py
+++ b/nau_openedx_extensions/partner_integration/models.py
@@ -70,6 +70,12 @@ class PartnerAPIClient(AbstractBaseUser, PermissionsMixin):
         self.validate_basis(self.query_security_scope)
         super().save(*args, **kwargs)
 
+    def check_password(self, password):
+        """
+        Override check_password in order to have a different behavior.
+        """
+        return password == self.password
+
     @property
     def email(self):
         """

--- a/nau_openedx_extensions/partner_integration/tests/test_api.py
+++ b/nau_openedx_extensions/partner_integration/tests/test_api.py
@@ -49,7 +49,7 @@ class BaseStructure:
                 is_active=True,
                 query_security_scope={"base_security_scope": {"org": f"TEST_ORG_{index}"}}
             )
-            partner_client.set_password("correct_password")
+            partner_client.password = "correct_password"
             partner_client.save()
             base_data["partner_clients"].append(partner_client)
 
@@ -110,7 +110,7 @@ class TestPartnerClientTokenView(TransactionTestCase):
 
     def test_invalid_password_returns_403(self):
         """test that an invalid password returns 403."""
-        self.partner_client.set_password("correct_password")
+        self.partner_client.password = "correct_password"
         self.partner_client.save()
         self.http_client.credentials(
             HTTP_AUTHORIZATION="Token wrong_password",
@@ -123,7 +123,7 @@ class TestPartnerClientTokenView(TransactionTestCase):
     @patch.object(ClientJWTAuthentication, 'issue_client_jwt', return_value="mocked_jwt")
     def test_successful_token_returns_200_mocked_jwt(self, mock_jwt):
         """test that a valid password returns 200 and a token."""
-        self.partner_client.set_password("correct_password")
+        self.partner_client.password = "correct_password"
         self.partner_client.save()
         self.http_client.credentials(
             HTTP_AUTHORIZATION="Token correct_password",
@@ -136,7 +136,7 @@ class TestPartnerClientTokenView(TransactionTestCase):
 
     def test_successful_token_returns_200(self):
         """test that a valid password returns 200 and a token."""
-        self.partner_client.set_password("correct_password")
+        self.partner_client.password = "correct_password"
         self.partner_client.save()
         self.http_client.credentials(
             HTTP_AUTHORIZATION="Token correct_password",
@@ -164,7 +164,7 @@ class TestPartnerClientTokenView(TransactionTestCase):
 
     def test_check_token_format(self):
         """test that a valid password returns a JWT formatted token."""
-        self.partner_client.set_password("correct_password")
+        self.partner_client.password = "correct_password"
         self.partner_client.save()
         self.http_client.credentials(
             HTTP_AUTHORIZATION="Token correct_password",
@@ -520,7 +520,7 @@ class TestCertificateRestExportView(TransactionTestCase, BaseStructure):
             is_active=True,
             query_security_scope={"base_security_scope": {"org": org}}
         )
-        partner_client.set_password("correct_password")
+        partner_client.password = "correct_password"
         partner_client.save()
 
         courses = CourseOverviewFactory.create_batch(5, org=org)
@@ -988,7 +988,7 @@ class TestEnrollmentRestExportView(TransactionTestCase, BaseStructure):
             is_active=True,
             query_security_scope={"base_security_scope": {"org": org}}
         )
-        partner_client.set_password("correct_password")
+        partner_client.password = "correct_password"
         partner_client.save()
 
         courses = CourseOverviewFactory.create_batch(5, org=org)


### PR DESCRIPTION
In order to provide full context for the technical team the client's secret is shown via text field on the admin

related to: https://github.com/fccn/nau-technical/issues/674