### PR TITLE
fix: backends added to prevent circular imports in teak

### DIFF
--- a/nau_openedx_extensions/edxapp_wrapper/backends/course_module_t_v1.py
+++ b/nau_openedx_extensions/edxapp_wrapper/backends/course_module_t_v1.py
@@ -1,0 +1,58 @@
+""" Course block backend abstraction for Teak and later releases.
+
+This backend avoids importing CMS modules directly to prevent circular import issues
+that occur in Teak with the content.search module.
+"""
+
+import logging
+
+from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.django import modulestore  # pylint: disable=import-error
+
+log = logging.getLogger(__name__)
+
+
+def get_other_course_settings(course_id):
+    """Get Other Course Settings.
+    
+    This version directly accesses the course.other_course_settings attribute
+    instead of using CourseMetadata.fetch_all() from CMS, which causes
+    import issues in Teak due to the content.search module.
+    """
+    try:
+        course = modulestore().get_course(course_id)
+        if course is None:
+            log.error(f'Course not found: {course_id}')
+            return {}
+        # Access other_course_settings directly from the course object
+        # This returns a dict with 'value' key containing the actual settings
+        other_course_settings = getattr(course, 'other_course_settings', {})
+        # Wrap in the expected format if it's not already
+        if other_course_settings and 'value' not in other_course_settings:
+            return {'value': other_course_settings}
+        return {'value': other_course_settings} if other_course_settings else {}
+    except Exception as e:  # pylint: disable=broad-except
+        log.error(f'Error fetching other_course_settings for {course_id}: {e}')
+        return {}
+
+
+def get_course_name(course_id):
+    """Get the course name."""
+    try:
+        course = modulestore().get_course(course_id)
+        if course is None:
+            log.error(f'Course not found: {course_id}')
+            return ""
+        return course.display_name_with_default
+    except Exception as e:  # pylint: disable=broad-except
+        log.error(f'Error fetching course {course_id}: {e}')
+        return ""
+
+
+def get_course(course_key: CourseKey):
+    """Get the course object."""
+    try:
+        return modulestore().get_course(course_key)
+    except Exception as e:  # pylint: disable=broad-except
+        log.error(f'Error fetching course {course_key}: {e}')
+        return None

--- a/nau_openedx_extensions/edxapp_wrapper/backends/course_module_t_v1_tests.py
+++ b/nau_openedx_extensions/edxapp_wrapper/backends/course_module_t_v1_tests.py
@@ -1,0 +1,7 @@
+""" Course module backend tests for Teak """
+
+from nau_openedx_extensions.edxapp_wrapper.backends.course_module_t_v1 import (
+    get_other_course_settings,
+    get_course_name,
+    get_course,
+)

--- a/nau_openedx_extensions/settings/common.py
+++ b/nau_openedx_extensions/settings/common.py
@@ -58,7 +58,7 @@ def plugin_settings(settings):
         "nau_openedx_extensions.edxapp_wrapper.backends.registration_l_v1"
     )
     settings.NAU_COURSE_MODULE = (
-        "nau_openedx_extensions.edxapp_wrapper.backends.course_module_l_v1"
+        "nau_openedx_extensions.edxapp_wrapper.backends.course_module_t_v1"
     )
     settings.NAU_EMAIL_MODULE = (
         "nau_openedx_extensions.edxapp_wrapper.backends.email_module_l_v1"

--- a/nau_openedx_extensions/settings/test.py
+++ b/nau_openedx_extensions/settings/test.py
@@ -39,7 +39,7 @@ DATABASES = {
 }
 
 NAU_COURSE_MODULE = (
-    "nau_openedx_extensions.edxapp_wrapper.backends.course_module_l_v1_tests"
+    "nau_openedx_extensions.edxapp_wrapper.backends.course_module_t_v1_tests"
 )
 NAU_EMAIL_MODULE = (
     "nau_openedx_extensions.edxapp_wrapper.backends.email_module_l_v1_tests"

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,9 +1,9 @@
 # Same version as the platform
 celery>=5.2.2,<6.0.0
 Django<5.0
-edx-opaque-keys[django]==2.9.0
-openedx-filters==1.12.0
-openedx-events==9.15.0
+edx-opaque-keys[django]==3.0.0
+openedx-filters==2.0.1
+openedx-events==10.2.0
 # pip-tools==7.4.1
 click>=8.0,<9.0
 pylint<2.16.0


### PR DESCRIPTION
This PR fixes some issues regarding course imports.

It is related to the backend wrappers, I just created a new wrapper, this is in progress we should review it later.