### PR TITLE
fix: adjusted certificates extraction query

### DIFF
--- a/nau_openedx_extensions/partner_integration/facade.py
+++ b/nau_openedx_extensions/partner_integration/facade.py
@@ -174,7 +174,7 @@ class CertificateExportFacade(DataExtractorFacade):
                 filters |= Q(user__nauuserextendedmodel__cc_nif__in=nifs)
             filters &= Q(created_date__range=(start_dt, end_dt))
 
-            return use_read_replica_if_available(certificates_query.values_list("id", flat=True))
+            return use_read_replica_if_available(certificates_query.filter(filters).values_list("id", flat=True))
         except Exception as e:
             logger.error("Error executing certificates query.", exc_info=e)
             raise PartnerIntegrationInternalErrorException() from e
@@ -358,7 +358,6 @@ class EnrollmentFacade(DataExtractorFacade):
         """
         enrollments_query = CourseEnrollment.objects.filter(id__in=enrollment_ids)
         enrollments_query = enrollments_query.select_related("user", "course")
-        enrollments_query = self._annotate_certificates_data(enrollments_query)
         enrollments_query = enrollments_query.distinct()
 
         return enrollments_query
@@ -391,26 +390,9 @@ class EnrollmentFacade(DataExtractorFacade):
                 filters |= Q(user__nauuserextendedmodel__cc_nif__in=nifs)
             filters &= Q(created__range=(start_dt, end_dt))
 
-            enrollments_query = enrollments_query.filter(filters)
-
-            return use_read_replica_if_available(enrollments_query.values_list("id", flat=True))
+            return use_read_replica_if_available(enrollments_query.filter(filters).values_list("id", flat=True))
         except Exception as e:
             logger.error("Error executing enrollments query.", exc_info=e)
-            raise PartnerIntegrationInternalErrorException() from e
-
-    def _annotate_certificates_data(self, enrollments_query):
-        """Annotates enrollments with related certificates."""
-        try:
-            certificates_qs = GeneratedCertificate.objects.filter(
-                course_id=OuterRef("course_id")
-            )
-            return enrollments_query.annotate(
-                certificate_download_url=Subquery(certificates_qs.values("download_url")[:1]),
-                certificate_status=Subquery(certificates_qs.values("status")[:1]),
-                certificate_created=Subquery(certificates_qs.values("created_date")[:1]),
-            )
-        except Exception as e:
-            logger.error("Error annotating certificates data.", exc_info=e)
             raise PartnerIntegrationInternalErrorException() from e
 
 

--- a/nau_openedx_extensions/partner_integration/serializers.py
+++ b/nau_openedx_extensions/partner_integration/serializers.py
@@ -124,9 +124,6 @@ class EnrollUserRequestSerializer(serializers.Serializer):
 
 class CompleteEnrollmentDataSerializer(serializers.ModelSerializer):
     """Serializer to flatten course enrollment, user, and course data."""
-    certificate_created_date = serializers.DateTimeField(source='certificate_created', read_only=True)
-    certificate_status = serializers.CharField(read_only=True)
-    certificate_download_url = serializers.CharField(read_only=True)
     user_nif = serializers.CharField(source='user.nau_nif', read_only=True)
     username = serializers.CharField(source='user.username', read_only=True)
     user_name = serializers.SerializerMethodField()
@@ -150,9 +147,6 @@ class CompleteEnrollmentDataSerializer(serializers.ModelSerializer):
     class Meta:
         model = CourseEnrollment
         fields = [
-            "certificate_created_date",
-            "certificate_status",
-            "certificate_download_url",
             "user_nif",
             "username",
             "user_name",

--- a/nau_openedx_extensions/partner_integration/tests/test_api.py
+++ b/nau_openedx_extensions/partner_integration/tests/test_api.py
@@ -619,7 +619,7 @@ class TestCertificateRestExportView(TransactionTestCase, BaseStructure):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data["results"]), 50)
+        self.assertEqual(len(response.data["results"]), 30)
 
     def test_no_results_returns_empty_list(self):
         """
@@ -678,9 +678,6 @@ class TestEnrollmentRestExportView(TransactionTestCase, BaseStructure):
         partner_client = self.base_data["partner_clients"][0]
         access_token = self.authenticate_partner_client(partner_client)
         fields = [
-            "certificate_created_date",
-            "certificate_status",
-            "certificate_download_url",
             "user_nif",
             "username",
             "user_email",
@@ -706,7 +703,7 @@ class TestEnrollmentRestExportView(TransactionTestCase, BaseStructure):
         self.assertIn("results", response.data)
         self.assertTrue(len(response.data["results"]))
         fields_from_response = dict(response.data["results"][0]).keys()
-        self.assertEqual(len(fields_from_response), 16)
+        self.assertEqual(len(fields_from_response), 13)
         for field in fields:
             self.assertIn(field, fields_from_response)
 
@@ -876,7 +873,7 @@ class TestEnrollmentRestExportView(TransactionTestCase, BaseStructure):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["results"]), 100)
-        self.assertEqual(len(response.data["results"][0].keys()), 16)
+        self.assertEqual(len(response.data["results"][0].keys()), 13)
 
         has_next = True
         while has_next:


### PR DESCRIPTION
- The query filter was not being applied
- Removed the certification annotation from enrollments query, as it already exists an endpoint for retrieving only certificates.