### PR TITLE
feat: use only course_code to enroll and extract progress

### DIFF
--- a/nau_openedx_extensions/partner_integration/facade.py
+++ b/nau_openedx_extensions/partner_integration/facade.py
@@ -242,7 +242,7 @@ class EnrollmentFacade(DataExtractorFacade):
             logger.error("Error fetching enrollments.", exc_info=e)
             raise PartnerIntegrationInternalErrorException() from e
 
-    def enroll_user(self, query_security_scope, course_id, nif, email, username):
+    def enroll_user(self, query_security_scope, course_id, nif, email, username):  # pylint: disable=too-many-statements
         """
         Enrolls a user in a course using his NIF or email provided.
         It implements the enrollment logic using the Open edX enrollment API.
@@ -255,7 +255,16 @@ class EnrollmentFacade(DataExtractorFacade):
         try:
             base_security_scope = query_security_scope.get("base_security_scope", {})
             courses_base_query = super().apply_base_security_scope(base_security_scope)
-            course = courses_base_query.get(id=course_id)
+
+            try:
+                course = courses_base_query.get(id=course_id)
+            except Exception as e:  # pylint: disable=broad-except
+                courses = courses_base_query.filter(id__regex=course_id)
+                courses = [course for course in courses if course.is_enrollment_open()]
+                if not courses:
+                    raise CourseOverview.DoesNotExist()
+
+                course = courses[0]
 
             user = None
             if email:
@@ -439,14 +448,23 @@ class StudentProgressExportFacade(DataExtractorFacade):
 
             base_security_scope = query_security_scope.get("base_security_scope")
             courses_base_query = super().apply_base_security_scope(base_security_scope)
-            course = courses_base_query.filter(id=course)
-            if not course:
-                raise PartnerIntegrationCourseOwnerException()
-
-            course_key = CourseKey.from_string(course)
             student = self._get_student_user(student_id, nif, email, username)
 
-            course = get_course_or_403(student, 'load', course_key, check_if_enrolled=False)
+            try:
+                course_to_extract = courses_base_query.get(id=course)
+            except Exception as e:  # pylint: disable=broad-except
+                courses = courses_base_query.filter(id__regex=course)
+                courses = [c for c in courses if c.is_enrollment_open()]
+                if not courses:
+                    raise CourseOverview.DoesNotExist()
+
+                course_to_extract = courses[0]
+
+            if not course_to_extract:
+                raise PartnerIntegrationCourseOwnerException()
+
+            course_key = CourseKey.from_string(str(course_to_extract.id))
+            course_to_extract = get_course_or_403(student, 'load', course_key, check_if_enrolled=False)
             collected_block_structure = get_block_structure_manager(course_key).get_collected()
 
             course_grade = CourseGradeFactory().read(student, collected_block_structure=collected_block_structure)

--- a/nau_openedx_extensions/partner_integration/tests/test_api.py
+++ b/nau_openedx_extensions/partner_integration/tests/test_api.py
@@ -1330,6 +1330,41 @@ class TestPartnerRestIntegrationEnrollUserView(TransactionTestCase, BaseStructur
         self.assertEqual(response.data["user_email"], "success_nif_201@example.com")
         self.assertEqual(response.data["course_id"], str(course_id))
 
+    def test_enroll_user_success_course_code_201(self):
+        """
+        Test successful user enrollment using course code.
+        1. Authenticates a partner client.
+        2. Creates an external user with a known username.
+        3. Calls the enroll-user endpoint with the course code and username.
+        4. Validates the response indicates successful enrollment with correct details.
+        """
+        course_id = self.base_data["courses"][0].id
+        partner_client = self.base_data["partner_clients"][0]
+        access_token = self.authenticate_partner_client(partner_client)
+
+        external_user = NauUserExtendedModelFactory.create()
+        external_user.nif = "202020202"
+        external_user.user.email = "success_nif_201@example.com"
+        external_user.user.username = "username_202020202"
+        external_user.save()
+        external_user.user.save()
+
+        data = {
+            "course": str(course_id.course),
+            "username": external_user.user.username,
+        }
+        self.http_client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")
+        response = self.http_client.post(
+            self.endpoint,
+            data=data,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(len(response.data.keys()), 13)
+        self.assertEqual(response.data["username"], "username_202020202")
+        self.assertEqual(response.data["user_email"], "success_nif_201@example.com")
+        self.assertEqual(response.data["course_id"], str(course_id))
+
     def test_enroll_user_missing_course_returns_400(self):
         """
         Test that missing course ID returns 400 error.


### PR DESCRIPTION
This commit makes the webservice able to receive only the course_code to enroll users in courses and extract student progress.

Related to: fccn/nau-technical#758