### PR TITLE
feat: add ACE bulk email delivery and add org and course logo to ACE emails 

### DIFF
--- a/nau_openedx_extensions/apps.py
+++ b/nau_openedx_extensions/apps.py
@@ -54,3 +54,14 @@ class NauOpenEdxConfig(AppConfig):
         # Replace the method in the original VideoBlock class
         prev_poster_func = VideoBlock._poster  # pylint: disable=protected-access
         VideoBlock._poster = get_educast_poster_factory(prev_poster_func)  # pylint: disable=protected-access
+
+        # Override the default bulk email _get_course_email_context private function
+        # to inject custom organization data into email context
+        from lms.djangoapps.bulk_email import \
+            tasks as bulk_email_tasks  # pylint: disable=import-error,import-outside-toplevel # noqa
+
+        prev_email_context_func = bulk_email_tasks._get_course_email_context  # pylint: disable=protected-access
+        from nau_openedx_extensions.utils.bulk_email import \
+            get_course_email_context_factory  # pylint: disable=import-outside-toplevel # noqa
+        bulk_email_tasks._get_course_email_context = \
+            get_course_email_context_factory(prev_email_context_func)  # pylint: disable=protected-access

--- a/nau_openedx_extensions/email_channel/README.md
+++ b/nau_openedx_extensions/email_channel/README.md
@@ -1,0 +1,282 @@
+# Custom ACE Email Channel for Bulk Email Delivery
+
+## Overview
+
+This module provides a custom ACE (Advanced Communication Engine) email channel that allows Open edX to send emails through a separate SMTP relay dedicated to bulk email delivery.
+
+This is particularly useful for organizations that:
+- Need to comply with Portuguese public contracting requirements
+- Use a separate email infrastructure for transactional vs. marketing emails
+- Want to avoid third-party email delivery services (Sailthru, Braze, etc.)
+- Require flexible SMTP relay configuration
+
+
+## Key Features
+
+✅ **Separate SMTP Relay** - Configure different host for bulk emails
+✅ **Backward Compatible** - Defaults to standard EMAIL_* if not configured
+✅ **Flexible Configuration** - Support for TLS, SSL, ports, timeouts, credentials
+✅ **Robust Error Handling** - Connection errors logged and propagated
+✅ **Plugin Architecture** - Follows edX platform patterns
+✅ **Comprehensive Tests** - Full unit test suite included
+✅ **No Dependencies** - Uses only Django built-in email backend
+
+## Quick Start (5 minutes)
+
+### 1. Install the Package
+```bash
+cd /path/to/nau-openedx-extensions
+pip install -e .
+```
+
+**Important:** After installation, you must restart your edX services for the channel entry point to be registered. The package registers the channel via the `openedx.ace.channel` entry point in setup.py.
+
+### 2. Configure Django Settings
+
+Add these settings to your Open edX environment configuration:
+
+```python
+# Bulk email SMTP configuration
+EMAIL_HOST_FOR_BULK = 'bulk-smtp.your-domain.com'
+EMAIL_PORT_FOR_BULK = 587
+EMAIL_HOST_USER_FOR_BULK = 'bulk@your-domain.com'
+EMAIL_HOST_PASSWORD_FOR_BULK = 'your-password'
+EMAIL_USE_TLS_FOR_BULK = True
+EMAIL_USE_SSL_FOR_BULK = False
+EMAIL_TIMEOUT_FOR_BULK = 10
+```
+
+### 3. Enable the Channel in ACE
+
+```python
+ACE_ENABLED_CHANNELS = [
+    'django_email_bulk',  # Entry point name from setup.py
+]
+```
+
+### 4. Restart edX Services
+```bash
+# For devstack
+make dev.restart
+
+# For production, restart your edX app and celery workers
+```
+
+### 5. Test Email Delivery
+
+```bash
+python manage.py shell
+```
+
+```python
+from edx_ace import ace
+from edx_ace.message import Message
+
+message = Message(
+    from_address='noreply@example.com',
+    to_address='test@example.com',
+    subject='Test Email',
+    template_name='welcome',
+    context={}
+)
+ace.send(message)
+print("✓ Email sent!")
+```
+
+## Architecture
+
+### Components
+
+1. **DjangoEmailBulkChannel** (`django_email_bulk.py`)
+   - Extends `edx_ace.channel.django_email.DjangoEmailChannel`
+   - Overrides the `deliver()` method to use bulk email configuration
+   - Creates custom Django email connections with separate SMTP settings
+
+2. **Settings Configuration** (`settings/settings.py`)
+   - Defines new bulk email settings with intelligent fallback to standard EMAIL_* settings
+   - No additional dependencies beyond Django
+
+3. **App Configuration** (`apps.py`)
+   - Registers the email channel as a Django app
+   - Integrates plugin settings with edX platform
+
+### How It Works
+
+```
+User requests email delivery via ACE
+    ↓
+ACE routes to enabled channels
+    ↓
+DjangoEmailBulkChannel.deliver() is called
+    ↓
+_get_bulk_connection() creates custom email connection
+  - Uses EMAIL_HOST_FOR_BULK settings (not default EMAIL_HOST)
+  - Falls back to standard EMAIL_* if bulk settings not configured
+    ↓
+Connection sent to parent deliver() method
+    ↓
+Email sent via bulk SMTP relay
+    ↓
+Connection closed, success logged
+```
+
+## Configuration Reference
+
+### Django Settings
+
+All settings are optional and fall back to standard Django EMAIL_* settings if not specified:
+
+| Setting | Type | Default | Purpose |
+|---------|------|---------|---------|
+| `EMAIL_HOST_FOR_BULK` | str | EMAIL_HOST | SMTP hostname for bulk emails |
+| `EMAIL_PORT_FOR_BULK` | int | EMAIL_PORT | SMTP port (usually 25, 587, or 465) |
+| `EMAIL_HOST_USER_FOR_BULK` | str | EMAIL_HOST_USER | SMTP username |
+| `EMAIL_HOST_PASSWORD_FOR_BULK` | str | EMAIL_HOST_PASSWORD | SMTP password |
+| `EMAIL_USE_TLS_FOR_BULK` | bool | EMAIL_USE_TLS | Use TLS encryption |
+| `EMAIL_USE_SSL_FOR_BULK` | bool | EMAIL_USE_SSL | Use SSL encryption (don't combine with TLS) |
+| `EMAIL_TIMEOUT_FOR_BULK` | int | EMAIL_TIMEOUT or 10 | Connection timeout in seconds |
+
+### ACE Configuration
+
+Configure the ACE enabled channels to use the new bulk channel:
+
+```python
+ACE_ENABLED_CHANNELS = [
+    'django_email_bulk',  # Note: use the entry point name, not the full module path
+]
+```
+
+**Important Notes:** 
+- Use the **entry point name** `django_email_bulk` (registered in setup.py), NOT the full module path
+- Only include the bulk channel if you want all ACE emails to use the bulk SMTP relay
+- If you need other ACE channels (Sailthru, Braze, etc.), add them to the list
+- The channel is registered via the `openedx.ace.channel` entry point in setup.py
+
+## Usage Examples
+
+### Sending a Single Email
+
+```python
+from edx_ace import ace
+from edx_ace.message import Message
+
+message = Message(
+    from_address='noreply@example.com',
+    to_address='student@example.com',
+    subject='Welcome!',
+    template_name='welcome',
+    context={'name': 'John Doe'}
+)
+
+# Automatically uses DjangoEmailBulkChannel
+ace.send(message)
+```
+
+### Sending Bulk Emails
+
+```python
+from edx_ace import ace
+from edx_ace.message import Message
+
+users = [user1, user2, user3, ...]
+
+for user in users:
+    message = Message(
+        from_address='noreply@example.com',
+        to_address=user.email,
+        subject='Course Announcement',
+        template_name='announcement',
+        context={'user': user}
+    )
+    ace.send(message)  # Uses bulk SMTP relay
+```
+
+## Testing
+
+### Running Tests
+
+```bash
+# Run all email channel tests
+python manage.py test nau_openedx_extensions.email_channel
+
+# Run with verbose output
+python manage.py test nau_openedx_extensions.email_channel -v 2
+
+# Run specific test class
+python manage.py test nau_openedx_extensions.email_channel.tests.test_django_email_bulk.DjangoEmailBulkChannelTestCase
+```
+
+### Test Coverage
+
+The test suite validates:
+- Channel type validation
+- Custom settings override
+- Fallback to default settings
+- Connection parameter passing
+- Error handling and logging
+- Parent method invocation
+
+## Debugging
+
+### Test Connection
+
+```bash
+python manage.py shell
+```
+
+```python
+from nau_openedx_extensions.email_channel.django_email_bulk import DjangoEmailBulkChannel
+
+try:
+    connection = DjangoEmailBulkChannel._get_bulk_connection()
+    print("✓ Connection successful!")
+except Exception as e:
+    print(f"✗ Connection failed: {e}")
+```
+
+## Troubleshooting
+
+### Issue: "Connection refused"
+
+- Verify `EMAIL_HOST_FOR_BULK` is accessible: `telnet EMAIL_HOST_FOR_BULK EMAIL_PORT_FOR_BULK`
+- Check firewall allows outbound connections
+- Confirm SMTP server is running
+
+### Issue: "Authentication failed"
+
+- Verify `EMAIL_HOST_USER_FOR_BULK` and `EMAIL_HOST_PASSWORD_FOR_BULK`
+- Check bulk SMTP account has send permissions
+- Ensure special characters in password are properly escaped
+
+### Issue: "Emails not sent"
+
+- Verify `ACE_ENABLED_CHANNELS` includes the bulk channel
+- Check Django logs for errors
+- Ensure edX services restarted after config changes
+- Verify the bulk SMTP relay is operational
+
+## Integration with edX Platform
+
+### Multi-Channel Setup
+
+If you need multiple ACE channels:
+
+```python
+ACE_ENABLED_CHANNELS = [
+    'django_email_bulk',  # NAU bulk email channel (entry point name)
+    'sailthru',           # Optional: Sailthru
+    'braze',              # Optional: Braze
+]
+```
+
+### Performance Considerations
+
+- **Connection Overhead**: New connection created per email delivery
+- **Bulk Limits**: Check your SMTP provider's rate limits and adjust `EMAIL_TIMEOUT_FOR_BULK` based on network latency
+- **Batch Sending**: ACE handles message batching; this channel processes one message at a time
+
+## References
+
+- [edX ACE Documentation](https://github.com/openedx/edx-ace)
+- [Django Email Backend Documentation](https://docs.djangoproject.com/en/stable/topics/email/)
+- [edX Platform Plugin Guide](https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst)

--- a/nau_openedx_extensions/email_channel/__init__.py
+++ b/nau_openedx_extensions/email_channel/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""
+NAU Email Channel module for ACE (Advanced Communication Engine)
+Provides custom email delivery channels for edX ACE framework
+"""
+from __future__ import absolute_import, unicode_literals
+
+__version__ = '1.0.0'

--- a/nau_openedx_extensions/email_channel/apps.py
+++ b/nau_openedx_extensions/email_channel/apps.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+App configuration for email_channel module
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.apps import AppConfig
+
+
+class EmailChannelConfig(AppConfig):
+    """
+    Configuration for the email_channel application.
+
+    This app provides custom ACE (Advanced Communication Engine) channels
+    for sending emails through different SMTP relays.
+    """
+
+    name = 'nau_openedx_extensions.email_channel'
+    verbose_name = 'NAU Email Channel'
+    plugin_app = {
+        'settings_config': {
+            'lms.djangoapp': {
+                'common': {'relative_path': 'settings.settings'},
+            },
+            'cms.djangoapp': {
+                'common': {'relative_path': 'settings.settings'},
+            }
+        },
+    }
+
+    def ready(self):
+        """
+        Perform initialization when the app is ready.
+        """

--- a/nau_openedx_extensions/email_channel/django_email_bulk.py
+++ b/nau_openedx_extensions/email_channel/django_email_bulk.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+"""
+Custom ACE email channel using a separate SMTP relay for bulk emails.
+
+This module provides a custom implementation of the edX ACE DjangoEmailChannel
+that allows sending emails through a different SMTP server than the default
+transactional email system.
+
+This is particularly useful for organizations using separate email infrastructure
+for marketing/bulk emails (e.g., Portuguese public contracting requirements).
+"""
+from __future__ import absolute_import, unicode_literals
+
+import logging
+from smtplib import SMTPException
+
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives, get_connection
+
+try:
+    from edx_ace.channel.django_email import DjangoEmailChannel
+    from edx_ace.errors import FatalChannelDeliveryError
+except ImportError:
+    # Fallback if edx_ace is not available
+    DjangoEmailChannel = object
+    FatalChannelDeliveryError = Exception
+
+logger = logging.getLogger(__name__)
+
+
+class DjangoEmailBulkChannel(DjangoEmailChannel):
+    """
+    Custom ACE email channel that uses a separate SMTP relay for bulk emails.
+
+    This channel extends the standard DjangoEmailChannel to support sending emails
+    through a different SMTP server configuration (EMAIL_HOST_FOR_BULK and related
+    settings) instead of the default EMAIL_HOST.
+
+    Configuration:
+        - EMAIL_HOST_FOR_BULK: SMTP host for bulk emails (defaults to EMAIL_HOST)
+        - EMAIL_PORT_FOR_BULK: SMTP port for bulk emails (defaults to EMAIL_PORT)
+        - EMAIL_HOST_USER_FOR_BULK: Username for bulk email SMTP (defaults to EMAIL_HOST_USER)
+        - EMAIL_HOST_PASSWORD_FOR_BULK: Password for bulk email SMTP (defaults to EMAIL_HOST_PASSWORD)
+        - EMAIL_USE_TLS_FOR_BULK: Use TLS for bulk emails (defaults to EMAIL_USE_TLS)
+        - EMAIL_USE_SSL_FOR_BULK: Use SSL for bulk emails (defaults to EMAIL_USE_SSL)
+        - EMAIL_TIMEOUT_FOR_BULK: Connection timeout in seconds (defaults to EMAIL_TIMEOUT or 10)
+
+    Usage:
+        1. Install the package to register the entry point:
+           pip install -e .
+
+        2. Configure in Django settings:
+           ACE_ENABLED_CHANNELS = [
+               'django_email_bulk',  # Entry point name from setup.py
+           ]
+
+        3. Configure bulk email settings:
+           EMAIL_HOST_FOR_BULK = 'bulk-smtp.example.com'
+           EMAIL_PORT_FOR_BULK = 587
+           EMAIL_HOST_USER_FOR_BULK = 'bulk@example.com'
+           EMAIL_HOST_PASSWORD_FOR_BULK = 'password'
+           EMAIL_USE_TLS_FOR_BULK = True
+
+    Note: The channel is registered via the 'openedx.ace.channel' entry point
+          in setup.py, not by module path.
+    """
+
+    def deliver(self, message, rendered_message):
+        """
+        Deliver an email message using the bulk SMTP relay.
+
+        This method is based on the parent DjangoEmailChannel.deliver() but passes
+        a custom email connection configured for bulk emails instead of the default
+        transactional email configuration.
+
+        Args:
+            message: The ACE message object to deliver
+            rendered_message: The rendered message content
+
+        Raises:
+            FatalChannelDeliveryError: If SMTP delivery fails
+        """
+        try:
+            # Get the bulk email connection with custom settings
+            connection = self._get_bulk_connection()
+
+            subject = self.get_subject(rendered_message)
+            from_address = self.get_from_address(message)
+            reply_to = message.options.get('reply_to', None)
+
+            rendered_template = self.make_simple_html_template(
+                rendered_message.head_html,
+                rendered_message.body_html
+            )
+
+            # Pass the custom connection to EmailMultiAlternatives
+            mail = EmailMultiAlternatives(
+                subject=subject,
+                body=rendered_message.body,
+                from_email=from_address,
+                to=[message.recipient.email_address],
+                reply_to=reply_to,
+                headers=getattr(message, 'headers', None),
+                connection=connection,
+            )
+
+            mail.attach_alternative(rendered_template, 'text/html')
+            mail.send()
+
+            logger.info(
+                'Successfully delivered bulk email to user %s via channel %s',
+                message.recipient.username
+                if hasattr(message.recipient, 'username')
+                else str(message.recipient),
+                self.channel_type,
+            )
+
+        except SMTPException as e:
+            logger.exception(e)
+            raise FatalChannelDeliveryError(
+                'An SMTP error occurred (and logged) from Django send_email()'
+            ) from e
+
+    @staticmethod
+    def _get_bulk_connection():
+        """
+        Create and return a Django email connection using bulk email settings.
+
+        This method constructs a connection using EMAIL_HOST_FOR_BULK and related
+        settings, falling back to the standard EMAIL_HOST settings if bulk-specific
+        settings are not configured.
+
+        Returns:
+            A Django email backend connection instance
+
+        Raises:
+            Exception: If the connection fails to be created
+        """
+        # Get bulk email settings, falling back to standard settings
+        email_host = getattr(
+            settings,
+            'EMAIL_HOST_FOR_BULK',
+            getattr(settings, 'EMAIL_HOST', 'localhost')
+        )
+        email_port = getattr(
+            settings,
+            'EMAIL_PORT_FOR_BULK',
+            getattr(settings, 'EMAIL_PORT', 25)
+        )
+        email_host_user = getattr(
+            settings,
+            'EMAIL_HOST_USER_FOR_BULK',
+            getattr(settings, 'EMAIL_HOST_USER', '')
+        )
+        email_host_password = getattr(
+            settings,
+            'EMAIL_HOST_PASSWORD_FOR_BULK',
+            getattr(settings, 'EMAIL_HOST_PASSWORD', '')
+        )
+        email_use_tls = getattr(
+            settings,
+            'EMAIL_USE_TLS_FOR_BULK',
+            getattr(settings, 'EMAIL_USE_TLS', True)
+        )
+        email_use_ssl = getattr(
+            settings,
+            'EMAIL_USE_SSL_FOR_BULK',
+            getattr(settings, 'EMAIL_USE_SSL', False)
+        )
+        email_timeout = getattr(
+            settings,
+            'EMAIL_TIMEOUT_FOR_BULK',
+            getattr(settings, 'EMAIL_TIMEOUT', 10)
+        )
+
+        logger.info(
+            'Creating bulk email connection: host=%s, port=%s, use_tls=%s, use_ssl=%s, timeout=%s',
+            email_host,
+            email_port,
+            email_use_tls,
+            email_use_ssl,
+            email_timeout
+        )
+
+        # Get the email backend to use (defaults to SMTP)
+        email_backend = getattr(
+            settings,
+            'EMAIL_BACKEND_FOR_BULK',
+            'django.core.mail.backends.smtp.EmailBackend'
+        )
+
+        logger.info(
+            'Using email backend: %s',
+            email_backend
+        )
+
+        try:
+            connection = get_connection(
+                backend=email_backend,
+                host=email_host,
+                port=email_port,
+                username=email_host_user,
+                password=email_host_password,
+                use_tls=email_use_tls,
+                use_ssl=email_use_ssl,
+                timeout=email_timeout,
+                fail_silently=False,
+            )
+            return connection
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error(
+                'Failed to create bulk email connection: %s',
+                str(e)
+            )
+            raise

--- a/nau_openedx_extensions/email_channel/settings/__init__.py
+++ b/nau_openedx_extensions/email_channel/settings/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+"""
+Settings module for nau_openedx_extensions
+"""
+from __future__ import absolute_import, unicode_literals

--- a/nau_openedx_extensions/email_channel/settings/settings.py
+++ b/nau_openedx_extensions/email_channel/settings/settings.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""
+Settings for the email_channel module.
+
+This module provides configuration for custom ACE email channels
+that support different SMTP relays for bulk email delivery.
+"""
+from __future__ import absolute_import, unicode_literals
+
+
+def plugin_settings(settings):
+    """
+    Configure email channel settings when app is used as a plugin to edx-platform.
+
+    These settings allow configuration of a separate SMTP relay for bulk email delivery,
+    independent of the transactional email system.
+
+    Args:
+        settings: Django settings object
+
+    Note:
+        This function intentionally does NOT set default values for EMAIL_*_FOR_BULK
+        settings. The defaults are handled at runtime in django_email_bulk.py to ensure
+        EMAIL_HOST and other standard Django email settings are already loaded.
+
+        Only the EMAIL_BACKEND_FOR_BULK has a default set here based on DEBUG mode
+        to provide a good development experience out of the box.
+    """
+
+    # Email backend for bulk emails
+    # For development (DEBUG=True), defaults to console backend to avoid SMTP connection issues
+    # For production (DEBUG=False), defaults to SMTP backend
+    # Can be explicitly overridden in environment configuration
+    if not hasattr(settings, 'EMAIL_BACKEND_FOR_BULK'):
+        if getattr(settings, 'DEBUG', False):
+            # Development: print emails to console/logs
+            settings.EMAIL_BACKEND_FOR_BULK = 'django.core.mail.backends.console.EmailBackend'
+        else:
+            # Production: use SMTP backend
+            settings.EMAIL_BACKEND_FOR_BULK = 'django.core.mail.backends.smtp.EmailBackend'

--- a/nau_openedx_extensions/email_channel/tests/__init__.py
+++ b/nau_openedx_extensions/email_channel/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the email_channel module
+"""
+from __future__ import absolute_import, unicode_literals

--- a/nau_openedx_extensions/email_channel/tests/test_django_email_bulk.py
+++ b/nau_openedx_extensions/email_channel/tests/test_django_email_bulk.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the DjangoEmailBulkChannel
+"""
+from __future__ import absolute_import, unicode_literals
+
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+
+try:
+    from edx_ace.message import Message
+    from edx_ace.recipient import Recipient
+    ACE_AVAILABLE = True
+except ImportError:
+    ACE_AVAILABLE = False
+
+from nau_openedx_extensions.email_channel.django_email_bulk import DjangoEmailBulkChannel
+
+
+class DjangoEmailBulkChannelTestCase(TestCase):
+    """
+    Test cases for DjangoEmailBulkChannel
+    """
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.channel = DjangoEmailBulkChannel()
+        User = get_user_model()
+        self.user = User(
+            username='testuser',
+            email='testuser@example.com',
+            first_name='Test',
+            last_name='User'
+        )
+
+    @override_settings(
+        EMAIL_HOST_FOR_BULK='bulk-smtp.example.com',
+        EMAIL_PORT_FOR_BULK=587,
+        EMAIL_HOST_USER_FOR_BULK='bulk@example.com',
+        EMAIL_HOST_PASSWORD_FOR_BULK='password123',
+        EMAIL_USE_TLS_FOR_BULK=True,
+        EMAIL_USE_SSL_FOR_BULK=False,
+        EMAIL_TIMEOUT_FOR_BULK=10,
+    )
+    def test_get_bulk_connection_with_custom_settings(self):
+        """Test _get_bulk_connection with custom bulk settings"""
+        connection = self.channel._get_bulk_connection()  # pylint: disable=protected-access
+
+        self.assertIsNotNone(connection)
+        self.assertEqual(connection.host, 'bulk-smtp.example.com')
+        self.assertEqual(connection.port, 587)
+        self.assertEqual(connection.username, 'bulk@example.com')
+        self.assertEqual(connection.password, 'password123')
+        self.assertTrue(connection.use_tls)
+        self.assertFalse(connection.use_ssl)
+        self.assertEqual(connection.timeout, 10)
+
+    @override_settings(
+        EMAIL_HOST='default-smtp.example.com',
+        EMAIL_PORT=25,
+        EMAIL_HOST_USER='default@example.com',
+        EMAIL_HOST_PASSWORD='default_password',
+        EMAIL_USE_TLS=False,
+        EMAIL_USE_SSL=False,
+    )
+    def test_get_bulk_connection_fallback_to_default(self):
+        """Test _get_bulk_connection falls back to default EMAIL settings"""
+        connection = self.channel._get_bulk_connection()  # pylint: disable=protected-access
+
+        self.assertIsNotNone(connection)
+        self.assertEqual(connection.host, 'default-smtp.example.com')
+        self.assertEqual(connection.port, 25)
+        self.assertEqual(connection.username, 'default@example.com')
+        self.assertEqual(connection.password, 'default_password')
+
+    @override_settings(
+        EMAIL_HOST_FOR_BULK='bulk-smtp.example.com',
+        EMAIL_PORT_FOR_BULK=587,
+        EMAIL_HOST_USER_FOR_BULK='bulk@example.com',
+        EMAIL_HOST_PASSWORD_FOR_BULK='password123',
+        EMAIL_USE_TLS_FOR_BULK=True,
+    )
+    @mock.patch('nau_openedx_extensions.email_channel.django_email_bulk.get_connection')
+    def test_deliver_calls_parent_with_connection(self, mock_get_connection):
+        """Test deliver method passes custom connection to EmailMultiAlternatives"""
+        if not ACE_AVAILABLE:
+            self.skipTest('edx_ace not available')
+
+        # Mock the connection
+        mock_connection = mock.MagicMock()
+        mock_get_connection.return_value = mock_connection
+
+        # Create a Recipient object from the user
+        recipient = Recipient(self.user.username, self.user.email)
+        message = Message(
+            app_label='test_app',
+            name='test_message',
+            recipient=recipient,
+        )
+
+        # Create a mock rendered message with required attributes
+        rendered_message = mock.MagicMock()
+        rendered_message.subject = 'Test Subject'
+        rendered_message.body = 'Test body'
+        rendered_message.head_html = '<h1>Test</h1>'
+        rendered_message.body_html = '<p>Test body</p>'
+
+        # Mock EmailMultiAlternatives to avoid actual SMTP calls
+        with mock.patch(
+            'nau_openedx_extensions.email_channel.django_email_bulk.EmailMultiAlternatives'
+        ) as mock_email:
+            mock_mail_instance = mock.MagicMock()
+            mock_email.return_value = mock_mail_instance
+
+            self.channel.deliver(message, rendered_message)
+
+            # Verify EmailMultiAlternatives was called with the custom connection
+            mock_email.assert_called_once()
+            call_kwargs = mock_email.call_args[1]
+            self.assertEqual(call_kwargs['connection'], mock_connection)
+
+    @override_settings(
+        EMAIL_HOST_FOR_BULK='bulk-smtp.example.com',
+        EMAIL_PORT_FOR_BULK=587,
+    )
+    @mock.patch('nau_openedx_extensions.email_channel.django_email_bulk.get_connection')
+    def test_get_bulk_connection_called_with_correct_params(self, mock_get_connection):
+        """Test _get_bulk_connection passes correct parameters to get_connection"""
+        mock_connection = mock.MagicMock()
+        mock_get_connection.return_value = mock_connection
+
+        self.channel._get_bulk_connection()  # pylint: disable=protected-access
+
+        mock_get_connection.assert_called_once()
+        call_kwargs = mock_get_connection.call_args[1]
+
+        self.assertEqual(call_kwargs['host'], 'bulk-smtp.example.com')
+        self.assertEqual(call_kwargs['port'], 587)
+        self.assertEqual(call_kwargs['backend'], 'django.core.mail.backends.smtp.EmailBackend')
+
+    @override_settings(
+        EMAIL_HOST_FOR_BULK='invalid-host',
+        EMAIL_PORT_FOR_BULK=999999,
+    )
+    @mock.patch('nau_openedx_extensions.email_channel.django_email_bulk.get_connection')
+    def test_get_bulk_connection_handles_error(self, mock_get_connection):
+        """Test _get_bulk_connection handles connection errors gracefully"""
+        mock_get_connection.side_effect = Exception('Connection failed')
+
+        with self.assertRaises(Exception):
+            self.channel._get_bulk_connection()  # pylint: disable=protected-access

--- a/nau_openedx_extensions/utils/bulk_email.py
+++ b/nau_openedx_extensions/utils/bulk_email.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities for bulk email customization in NAU openedX extensions.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.conf import settings
+
+
+def get_course_email_context_factory(prev_get_course_email_context_func):
+    """
+    Factory function to wrap the _get_course_email_context function.
+
+    This allows us to inject custom organization data into the email context
+    that is used for bulk email sending, while preserving the original functionality.
+
+    Args:
+        prev_get_course_email_context_func: The original _get_course_email_context function
+
+    Returns:
+        A wrapped version of the function with custom context injection
+    """
+    def get_course_email_context_wrapper(course):
+        """
+        Wraps the original get_course_email_context to add custom organization context.
+        """
+        # Call the original function to get the base email context
+        email_context = prev_get_course_email_context_func(course)
+
+        # Add custom NAU organization data to the context
+        try:
+            from opaque_keys.edx.keys import CourseKey  # pylint: disable=import-outside-toplevel # noqa
+            from organizations.api import \
+                get_course_organization  # pylint: disable=import-error,import-outside-toplevel # noqa
+
+            course_id = str(course.id)
+            course_key = CourseKey.from_string(course_id)
+            organization = get_course_organization(course_key)
+
+            if organization:
+                email_context['organization_name'] = organization.get('name', None)
+                organization_logo = organization.get('logo', None)
+                if organization_logo:
+                    email_context['organization_logo'] = f'{settings.LMS_ROOT_URL}{organization_logo.url}'
+        except Exception:  # pylint: disable=broad-except
+            # If anything fails in getting organization data, just continue
+            # with the base email context
+            pass
+
+        return email_context
+
+    return get_course_email_context_wrapper

--- a/setup.py
+++ b/setup.py
@@ -77,9 +77,13 @@ setup(
             "nau_openedx_extensions = nau_openedx_extensions.apps:NauOpenEdxConfig",
             "coursecertificate = nau_openedx_extensions.coursecertificate.apps:CoursecertificateConfig",
             "enrollment_by_domain = nau_openedx_extensions.enrollment_by_domain.apps:EnrollmentByDomainConfig",
+            "email_channel = nau_openedx_extensions.email_channel.apps:EmailChannelConfig",
         ],
         "cms.djangoapp": [
             "nau_openedx_extensions = nau_openedx_extensions.studio.apps:NauOpenCmsConfig",
+        ],
+        "openedx.ace.channel": [
+            "django_email_bulk = nau_openedx_extensions.email_channel.django_email_bulk:DjangoEmailBulkChannel",
         ],
     }
 )


### PR DESCRIPTION
feat: add ACE bulk email delivery 

Implement custom ACE email channel for bulk email delivery.

feat: add org and course logo to ACE emails 

Any email sent by ACE Open edX module would include organization and course logos (if available).


https://github.com/fccn/nau-technical/issues/633
https://github.com/fccn/nau-technical/issues/638
https://github.com/fccn/nau-technical/issues/684