### PR TITLE
fix: adjusted certificate url parameter

### DIFF
--- a/nau_openedx_extensions/partner_integration/serializers.py
+++ b/nau_openedx_extensions/partner_integration/serializers.py
@@ -3,6 +3,7 @@
 import logging
 from datetime import datetime
 
+from django.conf import settings
 from rest_framework import serializers
 
 from nau_openedx_extensions.edxapp_wrapper.certificates import GeneratedCertificate
@@ -14,11 +15,12 @@ from nau_openedx_extensions.partner_integration.exception import (
 
 logger = logging.getLogger(__name__)
 
+LMS_ROOT = getattr(settings, "LMS_ROOT_URL", "http://lms.nau.edu.pt")
+
 
 class CompleteCertificateDataSerializer(serializers.ModelSerializer):
     """Serializer to flatten certificate, user, and course enrollment data."""
     certificate_date = serializers.DateTimeField(source='created_date', read_only=True)
-    certificate_url = serializers.CharField(source='download_url', read_only=True)
     user_nif = serializers.CharField(source='user.nau_nif', read_only=True)
     user_email = serializers.EmailField(source='user.email', read_only=True)
     username = serializers.CharField(source='user.username', read_only=True)
@@ -26,12 +28,17 @@ class CompleteCertificateDataSerializer(serializers.ModelSerializer):
     course_name = serializers.CharField(source='course_display_name', read_only=True)
     enrollment_date = serializers.DateTimeField(read_only=True)
     name = serializers.SerializerMethodField()
+    certificate_url = serializers.SerializerMethodField()
 
     def get_name(self, obj):
         """Returns the full name of the user, or username if full name is not available."""
         user = obj.user
         full_name = user.get_full_name().strip()
         return full_name or user.username
+
+    def get_certificate_url(self, obj):
+        """Returns a computed value for certificate url."""
+        return f"{LMS_ROOT}/certificates/{obj.verify_uuid}"
 
     class Meta:
         model = GeneratedCertificate

--- a/nau_openedx_extensions/partner_integration/tests/test_api.py
+++ b/nau_openedx_extensions/partner_integration/tests/test_api.py
@@ -257,6 +257,31 @@ class TestCertificateRestExportView(TransactionTestCase, BaseStructure):
         self.assertIn("results", response.data)
         self.assertEqual(response.data["results"][0]["course_id"], str(certificate.course_id))
 
+    def test_successful_export_with_valid_certificate_url(self):
+        """
+        Tests a successful export with a valid course filter.
+        1. Authenticates a partner client.
+        2. Calls the data extractor endpoint with a valid course id.
+        3. Validates the response contains a certificate url that matches
+        the certificate's `verify_uuid`.
+        """
+        course_id = self.base_data["courses"][0].id
+        partner_client = self.base_data["partner_clients"][0]
+        access_token = self.authenticate_partner_client(partner_client)
+
+        self.http_client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")
+        response = self.http_client.post(
+            self.endpoint,
+            data={"courses": [str(course_id)]},
+            format="json",
+        )
+
+        certificate = GeneratedCertificate.objects.filter(course_id=str(course_id)).first()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("results", response.data)
+        self.assertTrue(str(certificate.verify_uuid) in response.data["results"][0]["certificate_url"])
+
     def test_empty_body_returns_all_courses(self):
         """
         Tests that an empty body returns all courses.


### PR DESCRIPTION
It concatenates the `verify_uuid` with the certificates path.

Related to: fccn/nau-technical#780