### PR TITLE
fix: certificate PDF download URL formatting

### DIFF
--- a/nau_openedx_extensions/certificate_export/management/commands/export_course_certificates.py
+++ b/nau_openedx_extensions/certificate_export/management/commands/export_course_certificates.py
@@ -80,7 +80,7 @@ class Command(BaseCommand):
             # iterate each certificate and append each certificate as a row
             for certificate in course_generated_certificates:
                 certificate_web_link_url = f"{lms_root_url}/certificates/{certificate.verify_uuid}"
-                certificate_download_pdf_link = certificate_download_url + certificate.verify_uuid
+                certificate_download_pdf_link = f"{certificate_download_url}/{certificate.verify_uuid}"
 
                 rows.append(
                     [

--- a/nau_openedx_extensions/certificate_export/tests/test_commands.py
+++ b/nau_openedx_extensions/certificate_export/tests/test_commands.py
@@ -476,7 +476,7 @@ class ExportCourseCertificatesCommandTest(TestCase):
         super().setUp()
         self.valid_course_id = "course-v1:NAU+Demo+DemoCourse"
         self.valid_course_key = CourseKey.from_string(self.valid_course_id)
-        self.valid_download_url = "https://example.com/certificates/"
+        self.valid_download_url = "https://example.com/certificates"
         self.lms_root_url = "https://lms.example.com"
 
         # Use the renamed import
@@ -628,7 +628,7 @@ class ExportCourseCertificatesCommandTest(TestCase):
         self.assertEqual(data_row[6], expected_web_link)
 
         # Verify download link format
-        expected_download_link = f"{self.valid_download_url}test-uuid-123"
+        expected_download_link = f"{self.valid_download_url}/test-uuid-123"
         self.assertEqual(data_row[7], expected_download_link)
 
     @patch_use_read_replica


### PR DESCRIPTION
The certificate download PDF link was missing a forward slash separator between the base URL and the certificate UUID, causing malformed URLs like "https://example.com/certificatestest-uuid-123" instead of the correct "https://example.com/certificates/test-uuid-123".

fccn/nau-technical#795