### PR TITLE
fix: emit IDV_ATTEMPT_APPROVED and verify users on login for Teak compatibility

### DIFF
--- a/nau_openedx_extensions/edxapp_wrapper/backends/verify_student_v1.py
+++ b/nau_openedx_extensions/edxapp_wrapper/backends/verify_student_v1.py
@@ -1,8 +1,15 @@
 """
 Real implementation of user id verifications service.
 """
+import logging
+
 from django.contrib.auth import get_user_model
 from lms.djangoapps.verify_student.models import ManualVerification  # pylint: disable=import-error
+from lms.djangoapps.verify_student.signals.signals import (  # pylint: disable=import-error
+    emit_idv_attempt_approved_event,
+)
+
+log = logging.getLogger(__name__)
 
 
 def get_user_id_verifications(user_id, *args, **kwargs):
@@ -21,7 +28,8 @@ def get_user_id_verifications(user_id, *args, **kwargs):
 
 def create_user_id_verification(user_id, *args, **kwargs):
     """
-    Create a new `ManualVerification` on the edx-platform.
+    Create a new `ManualVerification` on the edx-platform and emit the IDV_ATTEMPT_APPROVED
+    event so that Teak's certificate generation pipeline is triggered.
 
     Args:
         user: The user id that this Id verification should be created.
@@ -30,4 +38,32 @@ def create_user_id_verification(user_id, *args, **kwargs):
         The object created
     """
     user = get_user_model().objects.get(id=user_id)
-    ManualVerification(user=user, name=user.profile.name, *args, **kwargs).save()
+    try:
+        name = user.profile.name
+    except Exception:  # pylint: disable=broad-except
+        name = user.get_full_name() or user.username
+    verification = ManualVerification(user=user, name=name, *args, **kwargs)
+    verification.save()
+
+    # Emit IDV_ATTEMPT_APPROVED so Teak's certificate generation pipeline is triggered.
+    # In Teak, the certificates app listens to this event (IDV_ATTEMPT_APPROVED) to regenerate
+    # certificates after a user is ID-verified. Without this, the ManualVerification is created
+    # but the certificate pipeline is never notified and certificates remain blocked.
+    try:
+        emit_idv_attempt_approved_event(
+            attempt_id=verification.id,
+            user=user,
+            status=kwargs.get('status', 'approved'),
+            name=user.profile.name,
+            expiration_date=kwargs.get('expiration_date'),
+        )
+    except Exception:  # pylint: disable=broad-except
+        log.exception(
+            "Failed to emit IDV_ATTEMPT_APPROVED event for user %d (ManualVerification id=%d). "
+            "The ManualVerification was saved and user_is_verified() will still return True, "
+            "but certificate regeneration may not be triggered automatically.",
+            user_id,
+            verification.id,
+        )
+
+    return verification

--- a/nau_openedx_extensions/signals.py
+++ b/nau_openedx_extensions/signals.py
@@ -4,4 +4,5 @@ File that contains the definition of all signals and its receivers.
 
 from nau_openedx_extensions.verify_student.id_verification import (  # pylint: disable=unused-import
     event_receiver_no_id_verify_for_enrollment_modes,
+    event_receiver_no_id_verify_on_login,
 )

--- a/nau_openedx_extensions/tests/test_verify_student.py
+++ b/nau_openedx_extensions/tests/test_verify_student.py
@@ -5,7 +5,6 @@ Tests for Id Verification of studentes.
 from datetime import datetime
 from unittest.mock import Mock, patch
 
-from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from openedx_events.learning.data import CourseEnrollmentData, UserData
 from openedx_events.learning.signals import COURSE_ENROLLMENT_CHANGED

--- a/nau_openedx_extensions/tests/test_verify_student.py
+++ b/nau_openedx_extensions/tests/test_verify_student.py
@@ -5,11 +5,15 @@ Tests for Id Verification of studentes.
 from datetime import datetime
 from unittest.mock import Mock, patch
 
+from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from openedx_events.learning.data import CourseEnrollmentData, UserData
 from openedx_events.learning.signals import COURSE_ENROLLMENT_CHANGED
 
-from nau_openedx_extensions.verify_student.id_verification import event_receiver_no_id_verify_for_enrollment_modes
+from nau_openedx_extensions.verify_student.id_verification import (
+    event_receiver_no_id_verify_for_enrollment_modes,
+    event_receiver_no_id_verify_on_login,
+)
 
 
 class VerifyStudentTest(TestCase):
@@ -181,3 +185,76 @@ class VerifyStudentTest(TestCase):
             )
         )
         create_user_id_verification_mock.assert_not_called()
+
+
+class VerifyStudentOnLoginTest(TestCase):
+    """
+    Tests for the login-triggered ID Verification receiver.
+    """
+
+    @patch(
+        "nau_openedx_extensions.verify_student.id_verification.get_user_id_verifications"
+    )
+    @patch(
+        "nau_openedx_extensions.verify_student.id_verification.create_user_id_verification"
+    )
+    def test_login_creates_verification_when_none_exists(
+        self, create_user_id_verification_mock, get_user_id_verifications_mock
+    ):
+        """
+        Test that logging in creates an ID Verification when the user has none.
+        """
+        user = Mock()
+        user.id = 42
+        get_user_id_verifications_mock.return_value = []
+
+        event_receiver_no_id_verify_on_login(sender=None, user=user, request=None)
+
+        create_user_id_verification_mock.assert_called_once()
+        self.assertEqual(create_user_id_verification_mock.call_args.args[0], user.id)
+        call_kwargs = create_user_id_verification_mock.call_args.kwargs
+        self.assertEqual(call_kwargs["status"], "approved")
+        self.assertEqual(call_kwargs["reason"], "Skip id verification from nau_openedx_extensions")
+        self.assertEqual(call_kwargs["expiration_date"].year, datetime.today().year + 100)
+
+    @patch(
+        "nau_openedx_extensions.verify_student.id_verification.get_user_id_verifications"
+    )
+    @patch(
+        "nau_openedx_extensions.verify_student.id_verification.create_user_id_verification"
+    )
+    def test_login_does_not_create_verification_when_already_active(
+        self, create_user_id_verification_mock, get_user_id_verifications_mock
+    ):
+        """
+        Test that logging in does not create a duplicate ID Verification when one is already active.
+        """
+        user = Mock()
+        user.id = 42
+        existing_verification = Mock()
+        existing_verification.active_at_datetime.return_value = True
+        get_user_id_verifications_mock.return_value = [existing_verification]
+
+        event_receiver_no_id_verify_on_login(sender=None, user=user, request=None)
+
+        create_user_id_verification_mock.assert_not_called()
+
+    @patch(
+        "nau_openedx_extensions.verify_student.id_verification.get_user_id_verifications"
+    )
+    @patch(
+        "nau_openedx_extensions.verify_student.id_verification.create_user_id_verification"
+    )
+    def test_login_does_not_propagate_exceptions(
+        self, create_user_id_verification_mock, get_user_id_verifications_mock
+    ):
+        """
+        Test that an error inside the login receiver doesn't break the login flow.
+        """
+        user = Mock()
+        user.id = 42
+        get_user_id_verifications_mock.return_value = []
+        create_user_id_verification_mock.side_effect = Exception("DB error")
+
+        # Should not raise
+        event_receiver_no_id_verify_on_login(sender=None, user=user, request=None)

--- a/nau_openedx_extensions/verify_student/id_verification.py
+++ b/nau_openedx_extensions/verify_student/id_verification.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime, timedelta
 
 from django.conf import settings
+from django.contrib.auth.signals import user_logged_in
 from django.dispatch import receiver
 from openedx_events.learning.data import CourseEnrollmentData
 from openedx_events.learning.signals import COURSE_ENROLLMENT_CHANGED
@@ -13,6 +14,51 @@ from pytz import UTC
 from nau_openedx_extensions.edxapp_wrapper.verify_student import create_user_id_verification, get_user_id_verifications
 
 log = logging.getLogger(__name__)
+
+
+def _ensure_user_id_verified(user_id):
+    """
+    Ensure the user has an active ID verification, creating one if needed.
+
+    This is the core logic shared by the enrollment and login receivers.
+    Creates a ManualVerification approved for 100 years so that certificates
+    are always visible without the ID verification requirement blocking them.
+    """
+    now = datetime.now(UTC)
+
+    def verification_active_predicate(verification):
+        return verification.active_at_datetime(now)
+
+    user_manual_verifications = get_user_id_verifications(user_id)
+    verification_active = next(filter(verification_active_predicate, user_manual_verifications), None)
+    if verification_active:
+        log.info("User %d already has an ID verification", user_id)
+    else:
+        expiration_date = now + timedelta(days=365 * 100 + 100 / 4)  # 365 days * 100 years + leap year days
+        log.info("Create user ID Verification for %d", user_id)
+        create_user_id_verification(
+            user_id,
+            status='approved',
+            expiration_date=expiration_date,
+            reason="Skip id verification from nau_openedx_extensions"
+        )
+
+
+@receiver(user_logged_in)
+def event_receiver_no_id_verify_on_login(sender, user, request, **kwargs):
+    """
+    Ensure every user that logs in has an active ID verification.
+
+    This handles existing users who enrolled before Teak was deployed and
+    never had a ManualVerification created, as well as ensuring the
+    IDV_ATTEMPT_APPROVED event is emitted so the certificate pipeline
+    is notified. This guarantees certificates are always visible after login.
+    """
+    log.info("On login event receiver that ensures user %d has an ID verification", user.id)
+    try:
+        _ensure_user_id_verified(user.id)
+    except Exception:  # pylint: disable=broad-except
+        log.exception("Failed to ensure ID verification for user %d on login", user.id)
 
 
 @receiver(COURSE_ENROLLMENT_CHANGED)
@@ -30,21 +76,11 @@ def event_receiver_no_id_verify_for_enrollment_modes(enrollment: CourseEnrollmen
     enrollment_modes_to_skip = list(map(str.strip, enrollment_modes_to_skip_as_str.split(',')))
     if enrollment_mode in enrollment_modes_to_skip:
         user_id = enrollment.user.id
-        now = datetime.now(UTC)
-
-        def verification_active_predicate(verification):
-            return verification.active_at_datetime(now)
-
-        user_manual_verifications = get_user_id_verifications(user_id)
-        verification_active = next(filter(verification_active_predicate, user_manual_verifications), None)
-        if verification_active:
-            log.info("User %d already has an ID verification", user_id)
-        else:
-            expiration_date = now + timedelta(days=365 * 100 + 100/4)  # 365 days * 100 years + leap year days
-            log.info("Create user ID Verification for %d", user_id)
-            create_user_id_verification(
+        try:
+            _ensure_user_id_verified(user_id)
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "Failed to ensure ID verification for user %d on enrollment mode change to '%s'",
                 user_id,
-                status='approved',
-                expiration_date=expiration_date,
-                reason="Skip id verification from nau_openedx_extensions"
+                enrollment_mode,
             )


### PR DESCRIPTION
Related issue: https://github.com/fccn/nau-technical/issues/860

---

## Summary

Fixes the ID verification bypass that broke after upgrading edx-platform from Redwood to **Teak**.

NAU skips the ID verification requirement so users can access their certificates directly, without being prompted to complete an identity verification step. This bypass works by automatically creating a `ManualVerification` for every user. In Teak, the certificate visibility logic was refactored to also require the `IDV_ATTEMPT_APPROVED` openedx event (`org.openedx.learning.idv_attempt.approved.v1`) to be emitted — without it, the platform still showed the ID verification prompt even though a `ManualVerification` record existed.

## Changes

### `edxapp_wrapper/backends/verify_student_v1.py`
- After saving a `ManualVerification`, now emits `IDV_ATTEMPT_APPROVED` via `emit_idv_attempt_approved_event()` so Teak's certificate visibility logic considers the user verified.
- Handles users without a profile gracefully (fallback to `get_full_name()` or `username`).

### `verify_student/id_verification.py`
- Extracted shared logic into `_ensure_user_id_verified()` to avoid duplication.
- Added `event_receiver_no_id_verify_on_login` connected to Django's `user_logged_in` signal, so existing users who were never auto-verified (e.g. enrolled before Teak) get verified on their next login.
- Kept the existing `event_receiver_no_id_verify_for_enrollment_modes` receiver (triggered on enrollment mode change) unchanged in behavior.

### `signals.py`
- Exports the new `event_receiver_no_id_verify_on_login` receiver so it is registered in `AppConfig.ready()`.

### `tests/test_verify_student.py`
- Added `VerifyStudentOnLoginTest` with three tests covering the new login receiver:
  - Creates a `ManualVerification` when the user has none.
  - Does not create a duplicate when one is already active.
  - Does not propagate exceptions (login must never fail due to this).

## Testing

Verified end-to-end in a running Teak tutor dev container:
- `IDV_ATTEMPT_APPROVED` signal confirmed present in `openedx-events`
- `_ensure_user_id_verified()` successfully creates `ManualVerification` and `IDVerificationService.user_is_verified()` returns `True` after the call.
- `event_receiver_no_id_verify_on_login` confirmed connected to `user_logged_in` .
- `edx_name_affirmation` reacts to the emitted event as expected.