### PR TITLE
feat: added management view for SSO

### DIFF
--- a/nau_openedx_extensions/partner_integration/serializers.py
+++ b/nau_openedx_extensions/partner_integration/serializers.py
@@ -240,3 +240,10 @@ class CourseProgressSerializer(serializers.Serializer):
     completion_summary = CompletionSummarySerializer()
     course_grade = CourseGradeSerializer()
     grading_policy = GradingPolicySerializer()
+
+
+class SSOUserSerializer(serializers.Serializer):
+    """Serializer for SSO user data in data extractor responses."""
+    external_user_id = serializers.CharField()
+    username = serializers.CharField(source='user.username')
+    email = serializers.EmailField(source='user.email')

--- a/nau_openedx_extensions/partner_integration/tests/test_sso.py
+++ b/nau_openedx_extensions/partner_integration/tests/test_sso.py
@@ -190,3 +190,173 @@ class TestCustomAuthorizationView(TransactionTestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "https://www.nau.edu.pt")
+
+
+class TestPartnerSSOManagementView(TransactionTestCase):
+
+    def setUp(self):
+        self.http_client = APIClient()
+        self.endpoint = "/nau-openedx-extensions/partner-integration/sso/manage/"
+
+        self.partner_client = PartnerAPIClientFactory.create(
+            is_active=True,
+            query_security_scope={"base_security_scope": {"org": f"TEST_ORG"}}
+        )
+        self.partner_client.password = "correct_password"
+        self.partner_client.save()
+
+        self.jwt_token = self.authenticate_partner_client(self.partner_client)
+
+    def authenticate_partner_client(self, partner_client):
+        """
+        Issues a real access token by calling the partner-client auth endpoint.
+
+        The password used is "correct_password", as set in the create_bases method.
+        It is not a fake password, it is the real authentication flow working here.
+        """
+        self.http_client.credentials(
+            HTTP_AUTHORIZATION="Token correct_password",
+            HTTP_X_CLIENT_ID=partner_client.client_id,
+        )
+        response = self.http_client.post(
+            "/nau-openedx-extensions/partner-integration/auth-token/",
+            format="json"
+        )
+
+        assert response.status_code == 200, f"Auth failed: {response.data}"
+        return response.data["access_token"]
+
+    def test_delete_sso_register_success(self):
+        """
+        Validates the SSO register deletion process.
+        """
+        sso_register = SSOPartnerIntegrationFactory.create(
+            partner_client=self.partner_client, external_user_id="123456789")
+
+        self.assertTrue(SSOPartnerIntegration.objects.filter(external_user_id="123456789").exists())
+
+        self.http_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {self.jwt_token}",
+            HTTP_X_CLIENT_ID=self.partner_client.client_id,
+        )
+
+        response = self.http_client.delete(
+            self.endpoint,
+            data={"external_user_id": "123456789"},
+            format="json"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(
+            SSOPartnerIntegration.objects.filter(external_user_id="123456789").exists())
+
+    def test_delete_sso_register_missing_external_user_id(self):
+        """
+        Validates the SSO register deletion process when the external_user_id is missing.
+        """
+        self.http_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {self.jwt_token}",
+            HTTP_X_CLIENT_ID=self.partner_client.client_id,
+        )
+
+        response = self.http_client.delete(
+            self.endpoint,
+            data={},
+            format="json"
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data["error"], "External user ID must be provided to manage SSO.")
+
+    def test_delete_sso_register_invalid_external_user_id(self):
+        """
+        Validates the SSO register deletion process when the external_user_id is invalid.
+        """
+        self.http_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {self.jwt_token}",
+            HTTP_X_CLIENT_ID=self.partner_client.client_id,
+        )
+
+        response = self.http_client.delete(
+            self.endpoint,
+            data={"external_user_id": ""},
+            format="json"
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data["error"], "External user ID must be provided to manage SSO.")
+
+    def test_delete_sso_register_not_found(self):
+        """
+        Validates the SSO register deletion process when the register does not exist.
+        """
+        self.http_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {self.jwt_token}",
+            HTTP_X_CLIENT_ID=self.partner_client.client_id,
+        )
+
+        external_user_id = "non_existent_id"
+        response = self.http_client.delete(
+            self.endpoint,
+            data={"external_user_id": external_user_id},
+            format="json"
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.data["error"], f"SSO register with external_user_id '{external_user_id}' not found.")
+
+    def test_get_sso_registers(self):
+        """
+        Validates the SSO register retrieval process.
+        """
+        sso_register1 = SSOPartnerIntegrationFactory.create(
+            partner_client=self.partner_client, external_user_id="123456789")
+        sso_register2 = SSOPartnerIntegrationFactory.create(
+            partner_client=self.partner_client, external_user_id="987654321")
+
+        self.http_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {self.jwt_token}",
+            HTTP_X_CLIENT_ID=self.partner_client.client_id,
+        )
+
+        url = f"{self.endpoint}?external_user_id={sso_register1.external_user_id}"
+        response = self.http_client.get(url, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(isinstance(response.data, dict))
+        self.assertEqual(response.data["external_user_id"], "123456789")
+
+    def test_get_sso_registers_not_found(self):
+        """
+        Validates the SSO register retrieval process when no register is found.
+        """
+        self.http_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {self.jwt_token}",
+            HTTP_X_CLIENT_ID=self.partner_client.client_id,
+        )
+
+        url = f"{self.endpoint}?external_user_id=non_existent_id"
+        response = self.http_client.get(url, format="json")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.data["error"], "SSO register with external_user_id 'non_existent_id' not found.")
+
+    def test_get_sso_registers_missing_external_user_id(self):
+        """
+        Validates the SSO register retrieval process when the external_user_id is missing.
+        """
+        self.http_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {self.jwt_token}",
+            HTTP_X_CLIENT_ID=self.partner_client.client_id,
+        )
+
+        url = f"{self.endpoint}"
+        response = self.http_client.get(url, format="json")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data["error"], "External user ID must be provided to retrieve SSO registers.")

--- a/nau_openedx_extensions/partner_integration/urls.py
+++ b/nau_openedx_extensions/partner_integration/urls.py
@@ -27,4 +27,7 @@ urlpatterns = [
     path("sso/authorize/",
          views.CustomAuthorizationView.as_view(),
          name="oauth2_provider_authorize"),
+    path("sso/manage/",
+         views.PartnerSSOManagementView.as_view(),
+         name="nau_partner_sso_management"),
 ]

--- a/nau_openedx_extensions/partner_integration/views.py
+++ b/nau_openedx_extensions/partner_integration/views.py
@@ -37,6 +37,7 @@ from nau_openedx_extensions.partner_integration.serializers import (
     CourseProgressSerializer,
     DataExtractorRequestSerializer,
     EnrollUserRequestSerializer,
+    SSOUserSerializer,
 )
 
 logger = logging.getLogger(__name__)
@@ -559,3 +560,95 @@ class CustomAuthorizationView(AuthorizationView):
             return redirect(uri)
         except Exception as e:
             raise e
+
+
+class PartnerSSOManagementView(APIView):
+    """
+    Endpoint to manage SSO related operations.
+    """
+    authentication_classes = [ClientJWTAuthentication]
+    permission_classes = [IsAuthenticatedPartnerAPIClient]
+
+    def delete(self, request):
+        """
+        HTTP DELETE handler to manage SSO operations.
+        It accepts an external user ID to remove the SSO register.
+
+        Returns:
+            bool: True if the SSO register was successfully removed, False otherwise.
+
+        Example of payload:
+        {
+            "external_user_id": "external_user_123",
+        }
+        """
+        try:
+            logger.info("PartnerSSOManagementView: DELETE request received.")
+
+            client: PartnerAPIClient = request.partner_client
+            if not client.is_active:
+                logger.error("PartnerSSOManagementView: Inactive client attempted to access endpoint.")
+                raise PartnerIntegrationInactiveClientException()
+
+            external_user_id = request.data.get("external_user_id")
+            if not external_user_id:
+                error_message = "External user ID must be provided to manage SSO."
+                logger.error(f"PartnerSSOManagementView: {error_message}")
+
+                return Response({"error": error_message}, status=status.HTTP_400_BAD_REQUEST)
+
+            sso_register = SSOPartnerIntegration.objects.get(partner_client=client, external_user_id=external_user_id)
+            sso_register.delete()
+
+            return Response({"success": True}, status=status.HTTP_200_OK)
+        except SSOPartnerIntegration.DoesNotExist:
+            error_message = f"SSO register with external_user_id '{external_user_id}' not found."
+            logger.error(f"PartnerSSOManagementView: {error_message}")
+
+            return Response({"error": error_message}, status=status.HTTP_404_NOT_FOUND)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error("PartnerSSOManagementView: Unexpected error.", exc_info=e)
+            return Response(
+                {"error": "An unexpected error occurred, please contact support."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+    def get(self, request):
+        """
+        HTTP GET handler to retrieve SSO registers for the authenticated partner client.
+        """
+        try:
+            logger.info("PartnerSSOManagementView: GET request received.")
+
+            client: PartnerAPIClient = request.partner_client
+            if not client.is_active:
+                logger.error("PartnerSSOManagementView: Inactive client attempted to access endpoint.")
+                raise PartnerIntegrationInactiveClientException()
+
+            external_user_id = self.request.query_params.get("external_user_id")
+            # By the current implementation, we require the `external_user_id` to retrieve SSO registers,
+            # but it's clearly possible to exist scenarious where we want to retrieve all registers for
+            # a given client. For this to work, oriented by necessity, we need to change this implementation
+            # making this to consider more information beyond of only `external_user_id`.
+
+            if not external_user_id:
+                error_message = "External user ID must be provided to retrieve SSO registers."
+                logger.error(f"PartnerSSOManagementView: {error_message}")
+                return Response({"error": error_message}, status=status.HTTP_400_BAD_REQUEST)
+
+            logger.info(f"PartnerSSOManagementView: Retrieving SSO register for external_user_id '{external_user_id}'.")
+            sso_register = SSOPartnerIntegration.objects.get(partner_client=client, external_user_id=external_user_id)
+            serializer = SSOUserSerializer(sso_register)
+            data = serializer.data
+
+            return Response(data, status=status.HTTP_200_OK)
+        except SSOPartnerIntegration.DoesNotExist:
+            error_message = f"SSO register with external_user_id '{external_user_id}' not found."
+            logger.error(f"PartnerSSOManagementView: {error_message}")
+            return Response({"error": error_message}, status=status.HTTP_404_NOT_FOUND)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error("PartnerSSOManagementView: Unexpected error.", exc_info=e)
+            return Response(
+                {"error": "An unexpected error occurred, please contact support."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )


### PR DESCRIPTION
This PR introduces a new view for managing SSO operations in the Partner Integration module. The `PartnerSSOManagementView` class provides two main functionalities:

### Delete SSO Register

A `delete` method implementation that allows clients to remove an SSO register by providing the `external_user_id`. If the register exists, it will be deleted, and a success response will be returned. If the register does not exist, a 404 error will be returned.

### Retrieve SSO Register

A `get` method implementation allows clients to retrieve an SSO register associated with the authenticated partner client by providing the `external_user_id`. If the register exists, it will return the serialized data. If the register does not exist, a 404 error will be returned. If the `external_user_id` is not provided, a 400 error will be returned.

It is important to note that the current `get` (retrieve) implementation requires the `external_user_id` to retrieve SSO register, that is, it only filters. However, future enhancements may allow for retrieving all registers for a given client by considering additional parameters beyond just the `external_user_id`.

Example of response:

```json
{
    "external_user_id": "12345",
    "username": "john_doe",
    "email": "john.doe@example.com"
}
```

Receiving a response containing the SSO register means that the link between the external user and the internal user is valid and active. Otherwise, it would never find any matching register.

> The view was created focused on the current necessity, but it is open to growth to support more complex queries and operations related to SSO management.

Related to: fccn/nau-technical#956