### PR TITLE
fix: pin Django version on tests

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -13,3 +13,4 @@ django_mock_queries
 faker
 ddt
 autopep8
+Django<5.0,>=4.2


### PR DESCRIPTION
This was required to fix the lint command that counts on resources from upstream that are only compatible with Django versions `<5.0`. 

Related to: fccn/nau-technical#963