### PR TITLE
fix: recover choice text for div-wrapped MCQ/checkbox choices in problem responses report

### DIFF
--- a/nau_openedx_extensions/apps.py
+++ b/nau_openedx_extensions/apps.py
@@ -65,3 +65,25 @@ class NauOpenEdxConfig(AppConfig):
             get_course_email_context_factory  # pylint: disable=import-outside-toplevel # noqa
         bulk_email_tasks._get_course_email_context = \
             get_course_email_context_factory(prev_email_context_func)  # pylint: disable=protected-access
+
+        # Fix the "Problem Responses" report showing "Answer Text Missing" / an empty
+        # correct answer for multiple-choice/checkbox problems whose choices were authored
+        # with Studio's rich-text / per-choice feedback editor (see nau-technical#948).
+        # TODO(nau-technical#948): remove once fixed upstream in edx-platform/xblocks-contrib.
+        from xmodule.capa.capa_problem import \
+            LoncapaProblem  # pylint: disable=import-error,import-outside-toplevel # noqa
+        from xmodule.capa.inputtypes import \
+            ChoiceGroup  # pylint: disable=import-error,import-outside-toplevel # noqa
+        from nau_openedx_extensions.xblocks.capa_problem_responses import (  # pylint: disable=import-outside-toplevel # noqa
+            get_extract_choices_factory,
+            get_find_correct_answer_text_factory,
+        )
+
+        prev_extract_choices_func = ChoiceGroup.extract_choices  # pylint: disable=protected-access
+        ChoiceGroup.extract_choices = staticmethod(
+            get_extract_choices_factory(prev_extract_choices_func)  # pylint: disable=protected-access
+        )
+
+        prev_find_correct_answer_text_func = LoncapaProblem.find_correct_answer_text  # pylint: disable=protected-access
+        LoncapaProblem.find_correct_answer_text = \
+            get_find_correct_answer_text_factory(prev_find_correct_answer_text_func)  # pylint: disable=protected-access

--- a/nau_openedx_extensions/apps.py
+++ b/nau_openedx_extensions/apps.py
@@ -72,8 +72,8 @@ class NauOpenEdxConfig(AppConfig):
         # TODO(nau-technical#948): remove once fixed upstream in edx-platform/xblocks-contrib.
         from xmodule.capa.capa_problem import \
             LoncapaProblem  # pylint: disable=import-error,import-outside-toplevel # noqa
-        from xmodule.capa.inputtypes import \
-            ChoiceGroup  # pylint: disable=import-error,import-outside-toplevel # noqa
+        from xmodule.capa.inputtypes import ChoiceGroup  # pylint: disable=import-error,import-outside-toplevel # noqa
+
         from nau_openedx_extensions.xblocks.capa_problem_responses import (  # pylint: disable=import-outside-toplevel # noqa
             get_extract_choices_factory,
             get_find_correct_answer_text_factory,

--- a/nau_openedx_extensions/tests/test_capa_problem_responses.py
+++ b/nau_openedx_extensions/tests/test_capa_problem_responses.py
@@ -1,0 +1,173 @@
+"""
+Test cases for the capa "Problem Responses" report monkeypatches.
+
+See nau_openedx_extensions.xblocks.capa_problem_responses for the root
+cause of fccn/nau-technical#948 being fixed here.
+"""
+import unittest
+from unittest.mock import Mock
+
+from lxml import etree
+
+from nau_openedx_extensions.xblocks.capa_problem_responses import (
+    get_extract_choices_factory,
+    get_find_correct_answer_text_factory,
+)
+
+
+def _parse(xml_string):
+    return etree.fromstring(xml_string)
+
+
+class TestExtractChoicesFactory(unittest.TestCase):
+    """
+    Test cases for get_extract_choices_factory / extract_choices_wrapper.
+    """
+
+    def test_passthrough_when_not_text_only(self):
+        """
+        When text_only=False the wrapper must return the original result unmodified.
+        """
+        element = _parse('<choicegroup><choice name="choice_0">Text</choice></choicegroup>')
+        original_result = [('choice_0', '<div>Text</div>')]
+        original_func = Mock(return_value=original_result)
+        wrapper = get_extract_choices_factory(original_func)
+        i18n = Mock()
+
+        result = wrapper(element, i18n=i18n, text_only=False)
+
+        self.assertEqual(result, original_result)
+        original_func.assert_called_once_with(element, i18n, text_only=False)
+
+    def test_passthrough_when_text_already_present(self):
+        """
+        When the original implementation already found non-empty text, keep it as-is.
+        """
+        element = _parse('<choicegroup><choice name="choice_0">Plain text</choice></choicegroup>')
+        original_func = Mock(return_value=[('choice_0', 'Plain text')])
+        wrapper = get_extract_choices_factory(original_func)
+
+        result = wrapper(element, i18n=Mock(), text_only=True)
+
+        self.assertEqual(result, [('choice_0', 'Plain text')])
+
+    def test_recovers_text_nested_in_div(self):
+        """
+        Reproduces the nau-technical#948 bug: choice text wrapped in <div>, with a
+        <choicehint><div>...</div></choicehint> sibling, must resolve to just the
+        answer text (not the hint text, and not empty).
+        """
+        element = _parse(
+            '<choicegroup>'
+            '<choice name="choice_0" correct="false">'
+            '<div>Uma plataforma de bolsa de doutoramento.</div>'
+            '<choicehint><div>Hint text that must not leak into the answer.</div></choicehint>'
+            '</choice>'
+            '<choice name="choice_1" correct="true">'
+            '<div>Uma plataforma para criar e gerir curriculos cientificos.</div>'
+            '<choicehint><div>Another hint.</div></choicehint>'
+            '</choice>'
+            '</choicegroup>'
+        )
+        # Simulate the real (buggy) upstream behaviour: choice.text is None for both.
+        original_func = Mock(return_value=[('choice_0', None), ('choice_1', None)])
+        wrapper = get_extract_choices_factory(original_func)
+
+        result = wrapper(element, i18n=Mock(), text_only=True)
+
+        self.assertEqual(result, [
+            ('choice_0', 'Uma plataforma de bolsa de doutoramento.'),
+            ('choice_1', 'Uma plataforma para criar e gerir curriculos cientificos.'),
+        ])
+
+    def test_leaves_empty_when_no_nested_text_available(self):
+        """
+        If there really is no text anywhere (edge case), gracefully returns empty string
+        rather than raising.
+        """
+        element = _parse('<choicegroup><choice name="choice_0" correct="false"></choice></choicegroup>')
+        original_func = Mock(return_value=[('choice_0', None)])
+        wrapper = get_extract_choices_factory(original_func)
+
+        result = wrapper(element, i18n=Mock(), text_only=True)
+
+        self.assertEqual(result, [('choice_0', '')])
+
+
+class TestFindCorrectAnswerTextFactory(unittest.TestCase):
+    """
+    Test cases for get_find_correct_answer_text_factory / find_correct_answer_text_wrapper.
+    """
+
+    def test_passthrough_when_original_result_present(self):
+        """
+        When the original implementation already found a result, keep it as-is.
+        """
+        original_func = Mock(return_value='Some Answer')
+        wrapper = get_find_correct_answer_text_factory(original_func)
+
+        lcp = Mock()
+        result = wrapper(lcp, 'some_answer_id')
+
+        self.assertEqual(result, 'Some Answer')
+
+    def test_recovers_correct_text_nested_in_div(self):
+        """
+        Reproduces the nau-technical#948 bug for `Resposta Correta`: the correct
+        <choice>'s text is nested in a <div>, so the plain `text()` xpath used by the
+        original implementation returns nothing; the wrapper must recover it while
+        excluding <choicehint> content.
+        """
+        tree = _parse(
+            '<problem>'
+            '<multiplechoiceresponse id="p_1">'
+            '<choicegroup id="p_2_1">'
+            '<choice name="choice_0" correct="false">'
+            '<div>Wrong answer.</div>'
+            '<choicehint><div>Wrong hint.</div></choicehint>'
+            '</choice>'
+            '<choice name="choice_1" correct="true">'
+            '<div>Right answer.</div>'
+            '<choicehint><div>Right hint.</div></choicehint>'
+            '</choice>'
+            '</choicegroup>'
+            '</multiplechoiceresponse>'
+            '</problem>'
+        )
+        original_func = Mock(return_value='')
+        wrapper = get_find_correct_answer_text_factory(original_func)
+
+        lcp = Mock()
+        lcp.tree = tree
+        result = wrapper(lcp, 'p_2_1')
+
+        self.assertEqual(result, 'Right answer.')
+
+    def test_no_matching_element_falls_back_to_original(self):
+        """
+        If the answer_id can't be found in the tree at all, don't attempt recovery.
+        """
+        tree = _parse('<problem></problem>')
+        original_func = Mock(return_value='')
+        wrapper = get_find_correct_answer_text_factory(original_func)
+
+        lcp = Mock()
+        lcp.tree = tree
+        result = wrapper(lcp, 'missing_id')
+
+        self.assertEqual(result, '')
+
+    def test_optioninput_falls_back_to_original(self):
+        """
+        optioninput-based problems are already fully handled by the original
+        implementation and must not be touched by the recovery logic.
+        """
+        tree = _parse('<problem><optioninput id="p_2_1" correct="Yes"/></problem>')
+        original_func = Mock(return_value='')
+        wrapper = get_find_correct_answer_text_factory(original_func)
+
+        lcp = Mock()
+        lcp.tree = tree
+        result = wrapper(lcp, 'p_2_1')
+
+        self.assertEqual(result, '')

--- a/nau_openedx_extensions/tests/test_capa_problem_responses.py
+++ b/nau_openedx_extensions/tests/test_capa_problem_responses.py
@@ -93,6 +93,27 @@ class TestExtractChoicesFactory(unittest.TestCase):
 
         self.assertEqual(result, [('choice_0', '')])
 
+    def test_returns_original_result_on_choice_count_mismatch(self):
+        """
+        If the number of (name, text) tuples returned by the original implementation
+        doesn't match the number of <choice> children found (e.g. a future upstream
+        change to extract_choices's return shape), don't attempt recovery via zip()
+        (which would silently misalign choice text) -- just return the original result.
+        """
+        element = _parse(
+            '<choicegroup>'
+            '<choice name="choice_0" correct="false"><div>A</div></choice>'
+            '<choice name="choice_1" correct="true"><div>B</div></choice>'
+            '</choicegroup>'
+        )
+        original_result = [('choice_0', None)]  # only one tuple for two <choice> elements
+        original_func = Mock(return_value=original_result)
+        wrapper = get_extract_choices_factory(original_func)
+
+        result = wrapper(element, i18n=Mock(), text_only=True)
+
+        self.assertEqual(result, original_result)
+
 
 class TestFindCorrectAnswerTextFactory(unittest.TestCase):
     """

--- a/nau_openedx_extensions/xblocks/capa_problem_responses.py
+++ b/nau_openedx_extensions/xblocks/capa_problem_responses.py
@@ -40,6 +40,10 @@ Once an upstream fix lands in edx-platform/xblocks-contrib, remove these
 monkeypatches.
 """
 
+import logging
+
+log = logging.getLogger(__name__)
+
 
 def _extract_choice_nested_text(choice_element):
     """
@@ -78,6 +82,17 @@ def get_extract_choices_factory(prev_extract_choices_func):
             return choices
 
         choice_elements = [choice for choice in element if choice.tag == 'choice']
+        if len(choices) != len(choice_elements):
+            # Upstream's extract_choices should always return one (name, text)
+            # tuple per <choice> child; if that shape ever changes, log loudly
+            # instead of silently misaligning choice text via zip().
+            log.warning(
+                'ChoiceGroup.extract_choices returned %d choices but found %d '
+                '<choice> elements; skipping div-wrapped text recovery.',
+                len(choices), len(choice_elements),
+            )
+            return choices
+
         fixed_choices = []
         for (name, text), choice_element in zip(choices, choice_elements):
             if not text or not text.strip():
@@ -109,7 +124,7 @@ def get_find_correct_answer_text_factory(prev_find_correct_answer_text_func):
         if result:
             return result
 
-        xml_elements = self.tree.xpath('//*[@id="' + answer_id + '"]')
+        xml_elements = self.tree.xpath('//*[@id=$answer_id]', answer_id=answer_id)
         if not xml_elements:
             return result
 

--- a/nau_openedx_extensions/xblocks/capa_problem_responses.py
+++ b/nau_openedx_extensions/xblocks/capa_problem_responses.py
@@ -1,0 +1,130 @@
+"""
+Monkeypatches for the capa "Problem Responses" report generation.
+
+Fixes fccn/nau-technical#948: the "Resposta" (answer) and "Resposta Correta"
+(correct answer) columns of the "Problem Responses" report show
+"Answer Text Missing" / an empty value for multiple-choice/checkbox problems
+whose choices were authored with Studio's newer rich-text / per-choice
+feedback problem editor.
+
+Root cause
+----------
+That editor stores each choice's visible text wrapped inside a child
+element, e.g.::
+
+    <choice correct="true">
+        <div>Uma plataforma para criar e gerir currículos científicos.</div>
+        <choicehint><div>...</div></choicehint>
+    </choice>
+
+instead of as a direct text node of ``<choice>``, e.g.::
+
+    <choice correct="true">Some answer text</choice>
+
+``xmodule.capa.inputtypes.ChoiceGroup.extract_choices(..., text_only=True)``
+(used by ``LoncapaProblem.find_answer_text``) and
+``LoncapaProblem.find_correct_answer_text`` both only ever look at the
+``<choice>`` element's direct/immediate text node (``choice.text`` /
+``text()`` XPath axis), so they get an empty string for every choice
+authored in the newer format, even though the problem renders, grades, and
+displays feedback perfectly fine for students (that code path uses
+``stringify_children``, which does recurse into child elements).
+
+This module patches both lookups to fall back to a recursive text
+extraction (skipping ``<choicehint>``/``<compoundhint>`` feedback children)
+whenever the upstream logic returns an empty result, without changing any
+other behaviour.
+
+TODO(nau-technical#948): This is a stopgap fix for an upstream Open edX bug.
+Once an upstream fix lands in edx-platform/xblocks-contrib, remove these
+monkeypatches.
+"""
+
+
+def _extract_choice_nested_text(choice_element):
+    """
+    Recursively extract all visible text nested inside a <choice> element,
+    excluding <choicehint>/<compoundhint> children (feedback text shown only
+    after answering), to recover choice text authored inside a wrapper
+    element such as <div> rather than as a direct text node of <choice>.
+    """
+    text_parts = []
+    for child in choice_element:
+        if child.tag in ('choicehint', 'compoundhint'):
+            continue
+        text_parts.append(''.join(child.itertext()))
+    return ''.join(text_parts).strip()
+
+
+def get_extract_choices_factory(prev_extract_choices_func):
+    """
+    Factory to create a patched `ChoiceGroup.extract_choices` staticmethod.
+
+    Calls the original implementation first (preserving all its existing
+    behaviour, including validation/error handling), and only overrides
+    choice text that came back empty when `text_only=True`, by falling back
+    to `_extract_choice_nested_text`.
+    """
+
+    def extract_choices_wrapper(element, i18n, text_only=False):
+        """
+        Wrapped version of `ChoiceGroup.extract_choices` that fixes empty
+        choice text for `text_only=True` when the choice text is nested
+        inside a child element (e.g. `<div>`) instead of being a direct
+        text node of `<choice>`.
+        """
+        choices = prev_extract_choices_func(element, i18n, text_only=text_only)
+        if not text_only:
+            return choices
+
+        choice_elements = [choice for choice in element if choice.tag == 'choice']
+        fixed_choices = []
+        for (name, text), choice_element in zip(choices, choice_elements):
+            if not text or not text.strip():
+                text = _extract_choice_nested_text(choice_element)
+            fixed_choices.append((name, text))
+        return fixed_choices
+
+    return extract_choices_wrapper
+
+
+def get_find_correct_answer_text_factory(prev_find_correct_answer_text_func):
+    """
+    Factory to create a patched `LoncapaProblem.find_correct_answer_text` method.
+
+    Calls the original implementation first, and only falls back to a
+    recursive text extraction (skipping choicehint/compoundhint) when the
+    original result is empty, so behaviour for already-working problems is
+    unchanged.
+    """
+
+    def find_correct_answer_text_wrapper(self, answer_id):
+        """
+        Wrapped version of `LoncapaProblem.find_correct_answer_text` that
+        fixes an empty result for choices whose text is nested inside a
+        child element (e.g. `<div>`) instead of being a direct text node
+        of `<choice>`.
+        """
+        result = prev_find_correct_answer_text_func(self, answer_id)
+        if result:
+            return result
+
+        xml_elements = self.tree.xpath('//*[@id="' + answer_id + '"]')
+        if not xml_elements:
+            return result
+
+        xml_element = xml_elements[0]
+        if xml_element.tag == 'optioninput' or xml_element.xpath('@answer'):
+            # These cases are already fully handled (and not text-based) by
+            # the original implementation; nothing more we can recover here.
+            return result
+
+        correct_choices = xml_element.xpath('*[@correct="true"]')
+        if not correct_choices:
+            return result
+
+        texts = [_extract_choice_nested_text(choice) for choice in correct_choices]
+        combined_text = ', '.join(text for text in texts if text)
+        return combined_text or result
+
+    return find_correct_answer_text_wrapper


### PR DESCRIPTION
## What
Monkeypatches `ChoiceGroup.extract_choices` and `LoncapaProblem.find_correct_answer_text` so the "Problem Responses" instructor report correctly resolves answer text for multiple-choice/checkbox problems whose choices were authored with Studio's rich-text / per-choice feedback editor.

## Why
Fixes 
- fccn/nau-technical#948

That editor wraps each choice's visible text in a child element (e.g. `<div>`) instead of storing it as a direct text node of `<choice>`. The report-generation code only reads the immediate text node (`choice.text` / the `text()` XPath axis), so it falls back to `"Answer Text Missing"` / an empty correct-answer value for these choices — even though rendering and grading work fine for students, since those code paths recurse into child elements (`stringify_children`).

## Fix
Both lookups now fall back to a recursive text extraction (skipping `<choicehint>`/`<compoundhint>` feedback children) only when the original implementation returns an empty result, leaving all other behaviour unchanged.

This is a stopgap fix for an upstream Open edX bug. An upstream ticket will be filed once we've validated this works across environments, referencing this monkeypatch so it can be removed once fixed upstream.

## Testing
- Added unit tests covering both factories (happy path, passthrough, div-wrapped recovery, edge cases) — 8/8 passing.
- Reproduced the bug against real production OLX and confirmed the fix resolves it, with no regressions for plain-text (non-div) choices.
- Validated end-to-end in local dev environment: created a throwaway test course with the real broken OLX, answered it, and confirmed the generated "Problem Responses" CSV now shows the correct answer text via the instructor dashboard.
