### PR TITLE
fix: recover correct-answer text when joined fragments are blank/whitespace

### DIFF
--- a/nau_openedx_extensions/tests/test_capa_problem_responses.py
+++ b/nau_openedx_extensions/tests/test_capa_problem_responses.py
@@ -192,3 +192,41 @@ class TestFindCorrectAnswerTextFactory(unittest.TestCase):
         result = wrapper(lcp, 'p_2_1')
 
         self.assertEqual(result, '')
+
+    def test_recovers_correct_text_when_original_result_is_blank_separators_only(self):
+        """
+        Reproduces a variant of nau-technical#948 seen on pretty-printed/indented OLX
+        (e.g. after a Studio export/import round-trip): each `<choice>`'s text is
+        nested in a `<div>`, so the original implementation's `text()` xpath only
+        picks up whitespace text nodes between/around child elements. Joining those
+        blank fragments with ", " produces a *non-empty* string made up solely of
+        whitespace and comma separators (e.g. "\n  , \n  "), which must still be
+        treated as "no real answer" so the wrapper falls through to recovery instead
+        of returning that garbage string.
+        """
+        tree = _parse(
+            '<problem>'
+            '<multiplechoiceresponse id="p_1">'
+            '<choicegroup id="p_2_1">'
+            '<choice name="choice_0" correct="false">'
+            '<div>Wrong answer.</div>'
+            '<choicehint><div>Wrong hint.</div></choicehint>'
+            '</choice>'
+            '<choice name="choice_1" correct="true">'
+            '<div>Right answer.</div>'
+            '<choicehint><div>Right hint.</div></choicehint>'
+            '</choice>'
+            '</choicegroup>'
+            '</multiplechoiceresponse>'
+            '</problem>'
+        )
+        # Simulates joining whitespace-only text() fragments from a single matched
+        # <choice correct="true"> element that has multiple indented child elements.
+        original_func = Mock(return_value='\n        , \n        , \n      ')
+        wrapper = get_find_correct_answer_text_factory(original_func)
+
+        lcp = Mock()
+        lcp.tree = tree
+        result = wrapper(lcp, 'p_2_1')
+
+        self.assertEqual(result, 'Right answer.')

--- a/nau_openedx_extensions/xblocks/capa_problem_responses.py
+++ b/nau_openedx_extensions/xblocks/capa_problem_responses.py
@@ -35,6 +35,14 @@ extraction (skipping ``<choicehint>``/``<compoundhint>`` feedback children)
 whenever the upstream logic returns an empty result, without changing any
 other behaviour.
 
+A second, related failure mode affects ``find_correct_answer_text`` only:
+its ``', '.join(xml_element.xpath('*[@correct="true"]/text()'))`` can match
+multiple *whitespace-only* text nodes when the OLX is pretty-printed/indented
+(e.g. after a Studio export/import round-trip), producing a non-empty string
+made up solely of whitespace and comma separators instead of an empty one.
+See ``_BLANK_JOINED_TEXT_RE`` below for how this is detected and routed
+through the same recovery fallback.
+
 TODO(nau-technical#948): This is a stopgap fix for an upstream Open edX bug.
 Once an upstream fix lands in edx-platform/xblocks-contrib, remove these
 monkeypatches.
@@ -49,7 +57,7 @@ log = logging.getLogger(__name__)
 # actual answer text), which `find_correct_answer_text`'s original `', '.join(...)`
 # can produce when every joined `text()` fragment is itself blank (e.g. when choice
 # text is authored across multiple pretty-printed/indented whitespace text nodes).
-_BLANK_JOINED_TEXT_RE = re.compile(r'^[\s,]*$')
+_BLANK_JOINED_TEXT_RE = re.compile(r'[\s,]*')
 
 
 def _extract_choice_nested_text(choice_element):
@@ -128,7 +136,7 @@ def get_find_correct_answer_text_factory(prev_find_correct_answer_text_func):
         of `<choice>`.
         """
         result = prev_find_correct_answer_text_func(self, answer_id)
-        if result and not _BLANK_JOINED_TEXT_RE.match(result):
+        if result and not _BLANK_JOINED_TEXT_RE.fullmatch(result):
             return result
 
         xml_elements = self.tree.xpath('//*[@id=$answer_id]', answer_id=answer_id)

--- a/nau_openedx_extensions/xblocks/capa_problem_responses.py
+++ b/nau_openedx_extensions/xblocks/capa_problem_responses.py
@@ -41,8 +41,15 @@ monkeypatches.
 """
 
 import logging
+import re
 
 log = logging.getLogger(__name__)
+
+# Matches a string containing only whitespace and/or comma separators (i.e. no
+# actual answer text), which `find_correct_answer_text`'s original `', '.join(...)`
+# can produce when every joined `text()` fragment is itself blank (e.g. when choice
+# text is authored across multiple pretty-printed/indented whitespace text nodes).
+_BLANK_JOINED_TEXT_RE = re.compile(r'^[\s,]*$')
 
 
 def _extract_choice_nested_text(choice_element):
@@ -121,7 +128,7 @@ def get_find_correct_answer_text_factory(prev_find_correct_answer_text_func):
         of `<choice>`.
         """
         result = prev_find_correct_answer_text_func(self, answer_id)
-        if result:
+        if result and not _BLANK_JOINED_TEXT_RE.match(result):
             return result
 
         xml_elements = self.tree.xpath('//*[@id=$answer_id]', answer_id=answer_id)


### PR DESCRIPTION
## Summary

Follow-up to 

- #153 

After that fix was deployed to dev, a residual case of the
same bug (fccn/nau-technical#948) was found: for a real production problem
with pretty-printed/indented OLX (choice text nested in a `<div>`), "Resposta
Correta" was still empty in the Problem Responses report even though
"Resposta" was populated correctly.

## Root cause

`LoncapaProblem.find_correct_answer_text`'s `', '.join(xml_element.xpath('*[@correct="true"]/text()'))`
can match multiple whitespace-only text nodes when choice markup is indented,
joining them into a non-empty string that's just whitespace and commas (e.g.
`'\n        , \n        , \n      '`). The `find_correct_answer_text_wrapper`
added in #153 checked `if result:`, which treated this garbage string as an
already-resolved answer and skipped the `<div>`-recovery fallback entirely.

Single-line OLX doesn't reproduce this (no whitespace text nodes between
elements), which is why it wasn't caught in the original testing — it only
surfaces on indented/pretty-printed markup, such as what Studio produces on
export/import round-trips.

## Fix

Added a regex (`_BLANK_JOINED_TEXT_RE = re.compile(r'^[\s,]*$')`) to detect
"whitespace/comma-separators only" results and fall through to recovery in
that case too.

## Testing

- New unit test covering this exact scenario (blank-separators-only joined
  result) — all 10 tests pass.
- Verified against the exact real production OLX that surfaced the bug on
  `www.dev.nau.fccn.pt`, plus all prior regression cases (5-choice MCQ,
  plain-text, checkbox multi-select).
- Verified end-to-end in a local dev environment: imported the affected
  course, answered the problem, generated the Problem Responses report, and
  confirmed "Resposta Correta" is now populated.
- isort and pycodestyle clean.

Related to:

- fccn/nau-technical#948
