### PR TITLE
fix: recover question text for div-wrapped MCQ/checkbox problems

### DIFF
--- a/nau_openedx_extensions/apps.py
+++ b/nau_openedx_extensions/apps.py
@@ -67,8 +67,9 @@ class NauOpenEdxConfig(AppConfig):
             get_course_email_context_factory(prev_email_context_func)  # pylint: disable=protected-access
 
         # Fix the "Problem Responses" report showing "Answer Text Missing" / an empty
-        # correct answer for multiple-choice/checkbox problems whose choices were authored
-        # with Studio's rich-text / per-choice feedback editor (see nau-technical#948).
+        # correct answer, and "Question N" instead of the actual question text, for
+        # multiple-choice/checkbox problems whose choices were authored with Studio's
+        # rich-text / per-choice feedback editor (see nau-technical#948).
         # TODO(nau-technical#948): remove once fixed upstream in edx-platform/xblocks-contrib.
         from xmodule.capa.capa_problem import \
             LoncapaProblem  # pylint: disable=import-error,import-outside-toplevel # noqa
@@ -77,6 +78,7 @@ class NauOpenEdxConfig(AppConfig):
         from nau_openedx_extensions.xblocks.capa_problem_responses import (  # pylint: disable=import-outside-toplevel # noqa
             get_extract_choices_factory,
             get_find_correct_answer_text_factory,
+            get_find_question_label_factory,
         )
 
         prev_extract_choices_func = ChoiceGroup.extract_choices  # pylint: disable=protected-access
@@ -87,3 +89,7 @@ class NauOpenEdxConfig(AppConfig):
         prev_find_correct_answer_text_func = LoncapaProblem.find_correct_answer_text  # pylint: disable=protected-access
         LoncapaProblem.find_correct_answer_text = \
             get_find_correct_answer_text_factory(prev_find_correct_answer_text_func)  # pylint: disable=protected-access
+
+        prev_find_question_label_func = LoncapaProblem.find_question_label  # pylint: disable=protected-access
+        LoncapaProblem.find_question_label = \
+            get_find_question_label_factory(prev_find_question_label_func)  # pylint: disable=protected-access

--- a/nau_openedx_extensions/tests/test_capa_problem_responses.py
+++ b/nau_openedx_extensions/tests/test_capa_problem_responses.py
@@ -400,3 +400,78 @@ class TestFindQuestionLabelFactory(unittest.TestCase):
 
         self.assertEqual(wrapper(self._make_lcp(tree), 'x_2_1'), 'First item prompt')
         self.assertEqual(wrapper(self._make_lcp(tree), 'x_2_2'), 'Second item prompt')
+
+    def test_ignores_non_prompt_div_for_non_optioninput_answers(self):
+        """
+        `<div>` recovery is intentionally scoped to `<optioninput>` answers
+        only (see `_find_label_element_text`'s `allow_div` docstring): for
+        other response types (e.g. MCQ/checkbox), a `<div>` immediately
+        preceding the answer element is common for unrelated purposes (an
+        image wrapper, a shared/general instructions block, etc.), so it
+        must NOT be picked up as the question prompt -- doing so would
+        silently substitute incorrect text into the report instead of the
+        (at least honest) "Question N" placeholder.
+        """
+        tree = _parse(
+            '<problem><multiplechoiceresponse>'
+            '<div>Some unrelated image caption, not a question prompt.</div>'
+            '<choicegroup id="x_2_1">'
+            '<choice correct="true"><div>Answer</div></choice>'
+            '</choicegroup>'
+            '</multiplechoiceresponse></problem>'
+        )
+        original_func = Mock(return_value='Question 1')
+        wrapper = get_find_question_label_factory(original_func)
+
+        result = wrapper(self._make_lcp(tree), 'x_2_1')
+
+        self.assertEqual(result, 'Question 1')
+
+    def test_recovers_question_even_with_malformed_answer_id(self):
+        """
+        The generic-default detection must not depend on `answer_id`
+        matching the platform's usual `..._<n>_<m>` format: it's derived
+        from a regex over the translated template, not from parsing
+        `answer_id` itself, so recovery still works even for an unexpected
+        answer_id shape.
+        """
+        tree = _parse(
+            '<problem><multiplechoiceresponse>'
+            '<p>What is the real question?</p>'
+            '<choicegroup id="not-the-usual-id-format">'
+            '<choice correct="true"><div>Answer</div></choice>'
+            '</choicegroup>'
+            '</multiplechoiceresponse></problem>'
+        )
+        original_func = Mock(return_value='Question 1')
+        wrapper = get_find_question_label_factory(original_func)
+
+        result = wrapper(self._make_lcp(tree), 'not-the-usual-id-format')
+
+        self.assertEqual(result, 'What is the real question?')
+
+    def test_falls_back_gracefully_when_i18n_gettext_raises(self):
+        """
+        If `capa_system.i18n.gettext` is missing/raises an AttributeError or
+        TypeError for some reason (e.g. the i18n service itself being
+        unavailable/misconfigured), the wrapper must not propagate the
+        exception: it should log a warning and fall back to returning the
+        original (non-empty) result unmodified, exactly as if recovery had
+        been skipped.
+        """
+        tree = _parse(
+            '<problem><multiplechoiceresponse>'
+            '<p>Real question text</p>'
+            '<choicegroup id="x_2_1">'
+            '<choice correct="true"><div>Answer</div></choice>'
+            '</choicegroup>'
+            '</multiplechoiceresponse></problem>'
+        )
+        original_func = Mock(return_value='Question 1')
+        wrapper = get_find_question_label_factory(original_func)
+        lcp = self._make_lcp(tree)
+        lcp.capa_system.i18n.gettext = Mock(side_effect=AttributeError('i18n unavailable'))
+
+        result = wrapper(lcp, 'x_2_1')
+
+        self.assertEqual(result, 'Question 1')

--- a/nau_openedx_extensions/tests/test_capa_problem_responses.py
+++ b/nau_openedx_extensions/tests/test_capa_problem_responses.py
@@ -375,3 +375,28 @@ class TestFindQuestionLabelFactory(unittest.TestCase):
         result = wrapper(self._make_lcp(tree), 'x_2_1')
 
         self.assertEqual(result, 'Real question text')
+
+    def test_recovers_question_from_div_wrapped_prompt(self):
+        """
+        Reproduces a real production "matching" problem: a single
+        <optionresponse> containing several <optioninput> sub-answers, each
+        with its own <div> prompt immediately preceding it (not <p>/<label>).
+        The original implementation only recognises <p>/<label>, so it falls
+        back to the generic default for every sub-answer; the wrapper must
+        also recognise <div> and recover each sub-answer's own prompt.
+        """
+        tree = _parse(
+            '<problem><optionresponse>'
+            '<div>Overall instructions, not a specific prompt.</div>'
+            '<div>First item prompt</div>'
+            '<optioninput id="x_2_1"><option correct="true">A</option></optioninput>'
+            '<br/>'
+            '<div>Second item prompt</div>'
+            '<optioninput id="x_2_2"><option correct="true">B</option></optioninput>'
+            '</optionresponse></problem>'
+        )
+        original_func = Mock(return_value='Question 1')
+        wrapper = get_find_question_label_factory(original_func)
+
+        self.assertEqual(wrapper(self._make_lcp(tree), 'x_2_1'), 'First item prompt')
+        self.assertEqual(wrapper(self._make_lcp(tree), 'x_2_2'), 'Second item prompt')

--- a/nau_openedx_extensions/tests/test_capa_problem_responses.py
+++ b/nau_openedx_extensions/tests/test_capa_problem_responses.py
@@ -401,6 +401,56 @@ class TestFindQuestionLabelFactory(unittest.TestCase):
         self.assertEqual(wrapper(self._make_lcp(tree), 'x_2_1'), 'First item prompt')
         self.assertEqual(wrapper(self._make_lcp(tree), 'x_2_2'), 'Second item prompt')
 
+    def test_recovers_question_from_div_wrapped_prompt_with_trailing_br(self):
+        """
+        Same "matching" problem shape as `test_recovers_question_from_div_wrapped_prompt`,
+        but with a bare `<br/>` (layout/spacing only, no text) sitting directly
+        between the `<div>` prompt and its own `<optioninput>` -- a plausible
+        Studio/hand-authored OLX layout that isn't covered by the other test
+        (where the `<br/>` only appears *between* sub-answers, not between a
+        prompt and its own answer). `<br/>` must be skipped just like
+        `<description>`, otherwise the positional lookup lands on the `<br/>`
+        itself and silently fails to find the real prompt one element further
+        back, falling through to the generic "Question N" default.
+        """
+        tree = _parse(
+            '<problem><optionresponse>'
+            '<div>First item prompt</div>'
+            '<br/>'
+            '<optioninput id="x_2_1"><option correct="true">A</option></optioninput>'
+            '</optionresponse></problem>'
+        )
+        original_func = Mock(return_value='Question 1')
+        wrapper = get_find_question_label_factory(original_func)
+
+        result = wrapper(self._make_lcp(tree), 'x_2_1')
+
+        self.assertEqual(result, 'First item prompt')
+
+    def test_recovers_question_from_div_wrapped_prompt_with_hr_and_comment(self):
+        """
+        Same as the `<br/>` case above, but for the other structural/layout
+        noise elements the lookup must also skip: a bare `<hr/>` and an XML
+        comment. Both must be skipped just like `<br/>`/`<description>`,
+        otherwise the positional lookup lands on one of them (neither a
+        valid label nor previously in `SKIP_ELEMS`) and silently falls back
+        to the generic "Question N" default.
+        """
+        tree = _parse(
+            '<problem><optionresponse>'
+            '<div>First item prompt</div>'
+            '<hr/>'
+            '<!-- a hand-authored comment -->'
+            '<optioninput id="x_2_1"><option correct="true">A</option></optioninput>'
+            '</optionresponse></problem>'
+        )
+        original_func = Mock(return_value='Question 1')
+        wrapper = get_find_question_label_factory(original_func)
+
+        result = wrapper(self._make_lcp(tree), 'x_2_1')
+
+        self.assertEqual(result, 'First item prompt')
+
     def test_ignores_non_prompt_div_for_non_optioninput_answers(self):
         """
         `<div>` recovery is intentionally scoped to `<optioninput>` answers

--- a/nau_openedx_extensions/tests/test_capa_problem_responses.py
+++ b/nau_openedx_extensions/tests/test_capa_problem_responses.py
@@ -12,6 +12,7 @@ from lxml import etree
 from nau_openedx_extensions.xblocks.capa_problem_responses import (
     get_extract_choices_factory,
     get_find_correct_answer_text_factory,
+    get_find_question_label_factory,
 )
 
 
@@ -230,3 +231,147 @@ class TestFindCorrectAnswerTextFactory(unittest.TestCase):
         result = wrapper(lcp, 'p_2_1')
 
         self.assertEqual(result, 'Right answer.')
+
+
+class TestFindQuestionLabelFactory(unittest.TestCase):
+    """
+    Test cases for get_find_question_label_factory / find_question_label_wrapper.
+
+    See nau_openedx_extensions.xblocks.capa_problem_responses for the root
+    cause of the "Pergunta" (question) column showing "Questão N" instead of
+    the actual question text, a follow-up to fccn/nau-technical#948.
+    """
+
+    @staticmethod
+    def _make_lcp(tree):
+        """
+        Build a Mock LoncapaProblem-like object with just enough attributes
+        for find_question_label_wrapper: a real lxml tree and an i18n
+        gettext that's a no-op passthrough (like the real i18n service
+        would be for English source strings).
+        """
+        lcp = Mock()
+        lcp.tree = tree
+        lcp.capa_system.i18n.gettext = lambda text: text
+        return lcp
+
+    def test_passthrough_when_original_result_is_real_text(self):
+        """
+        When the original implementation already found real question text
+        (not the generic "Question N" default), keep it as-is.
+        """
+        tree = _parse('<problem><multiplechoiceresponse><choicegroup id="x_2_1"/></multiplechoiceresponse></problem>')
+        original_func = Mock(return_value='Real question text')
+        wrapper = get_find_question_label_factory(original_func)
+
+        result = wrapper(self._make_lcp(tree), 'x_2_1')
+
+        self.assertEqual(result, 'Real question text')
+
+    def test_recovers_question_nested_inside_response_tag(self):
+        """
+        Reproduces the actual production bug: Studio's rich-text/per-choice
+        feedback editor nests the question prompt *inside* the response tag,
+        as a sibling of the choice group, instead of as a sibling of the
+        response tag itself. The original implementation only checks the
+        latter, so it falls back to a generic "Question N" label; the
+        wrapper must recover the real prompt text (including from inline
+        rich-text markup like <strong>).
+        """
+        tree = _parse(
+            '<problem><multiplechoiceresponse>'
+            '<p><strong>O que e o CienciaVitae?</strong></p>'
+            '<choicegroup id="x_2_1">'
+            '<choice correct="true"><div>Answer</div></choice>'
+            '</choicegroup>'
+            '</multiplechoiceresponse></problem>'
+        )
+        # Simulate the real (buggy) upstream behaviour: falls back to the
+        # generic default because it looks one level too high in the tree.
+        original_func = Mock(return_value='Question 1')
+        wrapper = get_find_question_label_factory(original_func)
+
+        result = wrapper(self._make_lcp(tree), 'x_2_1')
+
+        self.assertEqual(result, 'O que e o CienciaVitae?')
+
+    def test_recovers_question_with_rich_text_markup_in_legacy_layout(self):
+        """
+        Even for the "legacy" layout the original implementation targets
+        (prompt as a sibling of the response tag itself), a prompt authored
+        with inline rich-text markup (e.g. <strong>) resolves to None via
+        the original's direct `.text` read; the wrapper must recover it via
+        recursive text extraction.
+        """
+        tree = _parse(
+            '<problem>'
+            '<p><strong>Legacy bold question text</strong></p>'
+            '<multiplechoiceresponse>'
+            '<choicegroup id="x_2_1">'
+            '<choice correct="true"><div>Answer</div></choice>'
+            '</choicegroup>'
+            '</multiplechoiceresponse></problem>'
+        )
+        # Simulate the real (buggy) upstream behaviour: None from choice.text.
+        original_func = Mock(return_value=None)
+        wrapper = get_find_question_label_factory(original_func)
+
+        result = wrapper(self._make_lcp(tree), 'x_2_1')
+
+        self.assertEqual(result, 'Legacy bold question text')
+
+    def test_no_matching_element_falls_back_to_original(self):
+        """
+        If the answer_id can't be found in the tree at all, don't attempt
+        recovery -- just return the original result unmodified.
+        """
+        tree = _parse('<problem></problem>')
+        original_func = Mock(return_value='Question 1')
+        wrapper = get_find_question_label_factory(original_func)
+
+        result = wrapper(self._make_lcp(tree), 'missing_id')
+
+        self.assertEqual(result, 'Question 1')
+
+    def test_falls_back_to_original_when_no_recovery_possible(self):
+        """
+        If neither the answer element's own preceding sibling nor its
+        parent's preceding sibling is a usable <p>/<label>, gracefully
+        return the original (default) result rather than raising or
+        returning an empty value.
+        """
+        tree = _parse(
+            '<problem><multiplechoiceresponse>'
+            '<choicegroup id="x_2_1">'
+            '<choice correct="true"><div>Answer</div></choice>'
+            '</choicegroup>'
+            '</multiplechoiceresponse></problem>'
+        )
+        original_func = Mock(return_value='Question 1')
+        wrapper = get_find_question_label_factory(original_func)
+
+        result = wrapper(self._make_lcp(tree), 'x_2_1')
+
+        self.assertEqual(result, 'Question 1')
+
+    def test_skips_description_elements_when_looking_for_label(self):
+        """
+        A <description> element (feedback text, not the question prompt)
+        immediately preceding the answer element must be skipped over so the
+        real <p>/<label> further back is still found.
+        """
+        tree = _parse(
+            '<problem><multiplechoiceresponse>'
+            '<p>Real question text</p>'
+            '<description>Some descriptive text, not the question.</description>'
+            '<choicegroup id="x_2_1">'
+            '<choice correct="true"><div>Answer</div></choice>'
+            '</choicegroup>'
+            '</multiplechoiceresponse></problem>'
+        )
+        original_func = Mock(return_value='Question 1')
+        wrapper = get_find_question_label_factory(original_func)
+
+        result = wrapper(self._make_lcp(tree), 'x_2_1')
+
+        self.assertEqual(result, 'Real question text')

--- a/nau_openedx_extensions/tests/test_capa_problem_responses.py
+++ b/nau_openedx_extensions/tests/test_capa_problem_responses.py
@@ -525,3 +525,61 @@ class TestFindQuestionLabelFactory(unittest.TestCase):
         result = wrapper(lcp, 'x_2_1')
 
         self.assertEqual(result, 'Question 1')
+
+
+class TestCombinedPatchesIntegration(unittest.TestCase):
+    """
+    Integration-style test exercising all three monkeypatches
+    (extract_choices, find_correct_answer_text, find_question_label)
+    together on a single synthetic rich-text MCQ tree -- the same overall
+    shape as a real problem authored with Studio's rich-text/per-choice
+    feedback editor (nau-technical#948): a nested, rich-text question
+    prompt, and choices whose text is wrapped in <div> rather than a
+    direct text node.
+
+    Each patch already has its own dedicated unit tests above (in
+    isolation); this test guards against a regression that only shows up
+    when all three are applied to the *same* tree, e.g. if a future change
+    to one patch's tree-walking logic accidentally interfered with another
+    (they don't share state today, but nothing prevents that from changing).
+    """
+
+    def test_all_three_patches_recover_correctly_on_the_same_tree(self):
+        tree = _parse(
+            '<problem>'
+            '<multiplechoiceresponse id="p_1">'
+            '<p><strong>What is the capital of Portugal?</strong></p>'
+            '<choicegroup id="p_2_1">'
+            '<choice name="choice_0" correct="false">'
+            '<div>Porto</div>'
+            '<choicehint><div>Wrong hint.</div></choicehint>'
+            '</choice>'
+            '<choice name="choice_1" correct="true">'
+            '<div>Lisbon</div>'
+            '<choicehint><div>Right hint.</div></choicehint>'
+            '</choice>'
+            '</choicegroup>'
+            '</multiplechoiceresponse>'
+            '</problem>'
+        )
+        choicegroup = tree.xpath('//choicegroup')[0]
+
+        lcp = Mock()
+        lcp.tree = tree
+        lcp.capa_system.i18n.gettext = lambda text: text
+
+        extract_choices_wrapper = get_extract_choices_factory(
+            Mock(return_value=[('choice_0', None), ('choice_1', None)]),
+        )
+        find_correct_answer_text_wrapper = get_find_correct_answer_text_factory(Mock(return_value=''))
+        find_question_label_wrapper = get_find_question_label_factory(Mock(return_value='Question 1'))
+
+        self.assertEqual(
+            extract_choices_wrapper(choicegroup, i18n=Mock(), text_only=True),
+            [('choice_0', 'Porto'), ('choice_1', 'Lisbon')],
+        )
+        self.assertEqual(find_correct_answer_text_wrapper(lcp, 'p_2_1'), 'Lisbon')
+        self.assertEqual(
+            find_question_label_wrapper(lcp, 'p_2_1'),
+            'What is the capital of Portugal?',
+        )

--- a/nau_openedx_extensions/xblocks/capa_problem_responses.py
+++ b/nau_openedx_extensions/xblocks/capa_problem_responses.py
@@ -73,7 +73,11 @@ prompt as a sibling of the answer element itself (in addition to the
 original sibling-of-response-tag lookup), and to extract text recursively
 (via ``itertext()``) instead of relying on the direct ``.text`` node, in
 both cases falling back to this recovery only when the original lookup
-didn't already find real question text.
+didn't already find real question text. It also recognises ``<div>`` as a
+valid prompt-wrapper element (in addition to ``<p>``/``<label>``), since
+"matching"/dropdown problems (``optionresponse`` with multiple
+``<optioninput>`` sub-answers) author each sub-answer's own prompt as a
+``<div>`` sibling immediately preceding it, rather than a ``<p>``/``<label>``.
 
 TODO(nau-technical#948): This is a stopgap fix for an upstream Open edX bug.
 Once an upstream fix lands in edx-platform/xblocks-contrib, remove these
@@ -194,14 +198,21 @@ def get_find_correct_answer_text_factory(prev_find_correct_answer_text_func):
 
 def _find_label_element_text(xml_element):
     """
-    Look for a `<p>`/`<label>` element immediately preceding `xml_element`
-    (skipping `<description>` elements, which are feedback text rather than
-    the question prompt), and return its text extracted recursively (via
-    `itertext()`, so inline rich-text markup like `<strong>` doesn't cause
-    an empty result), or `None` if no such element/text is found.
+    Look for a `<p>`/`<label>`/`<div>` element immediately preceding
+    `xml_element` (skipping `<description>` elements, which are feedback
+    text rather than the question prompt), and return its text extracted
+    recursively (via `itertext()`, so inline rich-text markup like
+    `<strong>` doesn't cause an empty result), or `None` if no such
+    element/text is found.
+
+    `<div>` is included alongside `<p>`/`<label>` to also recover prompts
+    for problems built with per-item `<div>` descriptions (e.g. a multi
+    `<optioninput>` "matching" problem, where each dropdown's own prompt is
+    a `<div>` sibling immediately preceding it), not just Studio's
+    rich-text-editor `<p>` prompts.
     """
     SKIP_ELEMS = ('description',)
-    LABEL_ELEMS = ('p', 'label')
+    LABEL_ELEMS = ('p', 'label', 'div')
 
     candidate = xml_element.getprevious()
     while candidate is not None and candidate.tag in SKIP_ELEMS:

--- a/nau_openedx_extensions/xblocks/capa_problem_responses.py
+++ b/nau_openedx_extensions/xblocks/capa_problem_responses.py
@@ -43,6 +43,38 @@ made up solely of whitespace and comma separators instead of an empty one.
 See ``_BLANK_JOINED_TEXT_RE`` below for how this is detected and routed
 through the same recovery fallback.
 
+Follow-up (still nau-technical#948): the "Pergunta" (question) column shows a
+generic "Question N" placeholder instead of the actual question text for the
+same problems. This is caused by ``LoncapaProblem.find_question_label``,
+which looks for the question prompt (a ``<p>``/``<label>`` element) as the
+sibling immediately *preceding the response tag itself*, e.g.::
+
+    <p>What is 2+2?</p>
+    <multiplechoiceresponse>
+        <choicegroup id="...">...</choicegroup>
+    </multiplechoiceresponse>
+
+But Studio's rich-text/per-choice-feedback editor instead nests the prompt
+*inside* the response tag, as a sibling of the choice group, e.g.::
+
+    <multiplechoiceresponse>
+        <p>What is 2+2?</p>
+        <choicegroup id="...">...</choicegroup>
+    </multiplechoiceresponse>
+
+so the original lookup walks up one level too many and never finds it,
+falling through to the "Question N" default. A second, independent bug
+affects even the "expected" (sibling-of-response-tag) layout: the prompt's
+text is read via the element's direct ``.text`` node only, so a prompt
+authored with any inline rich-text formatting (e.g. ``<p><strong>What is
+2+2?</strong></p>``) also resolves to empty/``None`` instead of the actual
+text. This module patches ``find_question_label`` to also look for the
+prompt as a sibling of the answer element itself (in addition to the
+original sibling-of-response-tag lookup), and to extract text recursively
+(via ``itertext()``) instead of relying on the direct ``.text`` node, in
+both cases falling back to this recovery only when the original lookup
+didn't already find real question text.
+
 TODO(nau-technical#948): This is a stopgap fix for an upstream Open edX bug.
 Once an upstream fix lands in edx-platform/xblocks-contrib, remove these
 monkeypatches.
@@ -158,3 +190,92 @@ def get_find_correct_answer_text_factory(prev_find_correct_answer_text_func):
         return combined_text or result
 
     return find_correct_answer_text_wrapper
+
+
+def _find_label_element_text(xml_element):
+    """
+    Look for a `<p>`/`<label>` element immediately preceding `xml_element`
+    (skipping `<description>` elements, which are feedback text rather than
+    the question prompt), and return its text extracted recursively (via
+    `itertext()`, so inline rich-text markup like `<strong>` doesn't cause
+    an empty result), or `None` if no such element/text is found.
+    """
+    SKIP_ELEMS = ('description',)
+    LABEL_ELEMS = ('p', 'label')
+
+    candidate = xml_element.getprevious()
+    while candidate is not None and candidate.tag in SKIP_ELEMS:
+        candidate = candidate.getprevious()
+
+    if candidate is not None and candidate.tag in LABEL_ELEMS:
+        text = ''.join(candidate.itertext()).strip()
+        if text:
+            return text
+    return None
+
+
+def get_find_question_label_factory(prev_find_question_label_func):
+    """
+    Factory to create a patched `LoncapaProblem.find_question_label` method.
+
+    Calls the original implementation first, and only falls back to the
+    recovery logic below when it returned the generic "Question N" default
+    (or nothing at all), so behaviour for already-working problems is
+    unchanged.
+    """
+
+    def find_question_label_wrapper(self, answer_id):
+        """
+        Wrapped version of `LoncapaProblem.find_question_label` that fixes
+        the question prompt not being found for problems whose choices were
+        authored with Studio's rich-text / per-choice feedback editor, which
+        nests the prompt (e.g. `<p>...</p>`) *inside* the response tag, as a
+        sibling of the answer element, rather than as a sibling of the
+        response tag itself (the only location the original implementation
+        checks). Also fixes prompts using inline rich-text markup (e.g.
+        `<p><strong>...</strong></p>`), which the original implementation
+        misses because it only reads the element's direct `.text` node.
+        """
+        result = prev_find_question_label_func(self, answer_id)
+
+        try:
+            # Named to avoid babel's translation-string extraction (which
+            # matches on the literal identifier `_`/`gettext`/etc.): this
+            # reconstructs the *same* already-translated default that
+            # `prev_find_question_label_func` computes internally, purely
+            # for sentinel comparison below, so it isn't new user-facing
+            # text requiring its own catalog entry in this package.
+            gettext_fn = self.capa_system.i18n.gettext
+            question_nr = int(answer_id.split('_')[-2]) - 1
+            default_label = gettext_fn("Question {}").format(question_nr)
+        except (IndexError, ValueError):
+            default_label = None
+
+        if result and result != default_label:
+            return result
+
+        xml_elements = self.tree.xpath('//*[@id=$answer_id]', answer_id=answer_id)
+        if len(xml_elements) != 1:
+            return result
+
+        xml_element = xml_elements[0]
+
+        # Studio's rich-text/per-choice-feedback editor nests the question
+        # prompt inside the response tag, as a sibling of the answer element
+        # itself -- check that location first.
+        question_text = _find_label_element_text(xml_element)
+        if question_text:
+            return question_text
+
+        # Otherwise, re-check the "legacy" layout the original implementation
+        # targets (the prompt as a sibling of the parent response tag), using
+        # recursive text extraction in case the original only failed due to
+        # inline rich-text markup.
+        parent = xml_element.getparent()
+        if parent is None:
+            return result
+
+        question_text = _find_label_element_text(parent)
+        return question_text or result
+
+    return find_question_label_wrapper

--- a/nau_openedx_extensions/xblocks/capa_problem_responses.py
+++ b/nau_openedx_extensions/xblocks/capa_problem_responses.py
@@ -74,10 +74,15 @@ original sibling-of-response-tag lookup), and to extract text recursively
 (via ``itertext()``) instead of relying on the direct ``.text`` node, in
 both cases falling back to this recovery only when the original lookup
 didn't already find real question text. It also recognises ``<div>`` as a
-valid prompt-wrapper element (in addition to ``<p>``/``<label>``), since
-"matching"/dropdown problems (``optionresponse`` with multiple
-``<optioninput>`` sub-answers) author each sub-answer's own prompt as a
-``<div>`` sibling immediately preceding it, rather than a ``<p>``/``<label>``.
+valid prompt-wrapper element for ``<optioninput>`` answers specifically (in
+addition to ``<p>``/``<label>``), since "matching"/dropdown problems
+(``optionresponse`` with multiple ``<optioninput>`` sub-answers) author each
+sub-answer's own prompt as a ``<div>`` sibling immediately preceding it,
+rather than a ``<p>``/``<label>``. This is intentionally scoped to
+``<optioninput>`` only, rather than applied to every response type: ``<div>``
+is too generic/common a tag elsewhere in capa OLX (images, layout wrappers,
+feedback blocks, etc.) to safely assume any preceding one is the question
+prompt.
 
 TODO(nau-technical#948): This is a stopgap fix for an upstream Open edX bug.
 Once an upstream fix lands in edx-platform/xblocks-contrib, remove these
@@ -196,23 +201,28 @@ def get_find_correct_answer_text_factory(prev_find_correct_answer_text_func):
     return find_correct_answer_text_wrapper
 
 
-def _find_label_element_text(xml_element):
+def _find_label_element_text(xml_element, allow_div=False):
     """
-    Look for a `<p>`/`<label>`/`<div>` element immediately preceding
-    `xml_element` (skipping `<description>` elements, which are feedback
-    text rather than the question prompt), and return its text extracted
-    recursively (via `itertext()`, so inline rich-text markup like
-    `<strong>` doesn't cause an empty result), or `None` if no such
-    element/text is found.
+    Look for a `<p>`/`<label>` element (or, if `allow_div` is True, also a
+    `<div>` element) immediately preceding `xml_element` (skipping
+    `<description>` elements, which are feedback text rather than the
+    question prompt), and return its text extracted recursively (via
+    `itertext()`, so inline rich-text markup like `<strong>` doesn't cause
+    an empty result), or `None` if no such element/text is found.
 
-    `<div>` is included alongside `<p>`/`<label>` to also recover prompts
-    for problems built with per-item `<div>` descriptions (e.g. a multi
-    `<optioninput>` "matching" problem, where each dropdown's own prompt is
-    a `<div>` sibling immediately preceding it), not just Studio's
-    rich-text-editor `<p>` prompts.
+    `allow_div` is intentionally opt-in (default False) and should only be
+    passed as True when `xml_element` is itself an `<optioninput>`: `<div>`
+    is an extremely common, generic container used throughout capa OLX for
+    many unrelated purposes (images, layout wrappers, feedback blocks not
+    tagged `<description>`, etc.), so treating any preceding `<div>` as a
+    question prompt for e.g. MCQ/checkbox problems risks silently
+    substituting unrelated text as the "question". It's only safe/intended
+    to recover per-item prompts for `<optioninput>`-based "matching"
+    problems, where each dropdown's own prompt is authored as a `<div>`
+    sibling immediately preceding it, not a `<p>`/`<label>`.
     """
     SKIP_ELEMS = ('description',)
-    LABEL_ELEMS = ('p', 'label', 'div')
+    LABEL_ELEMS = ('p', 'label', 'div') if allow_div else ('p', 'label')
 
     candidate = xml_element.getprevious()
     while candidate is not None and candidate.tag in SKIP_ELEMS:
@@ -249,20 +259,48 @@ def get_find_question_label_factory(prev_find_question_label_func):
         """
         result = prev_find_question_label_func(self, answer_id)
 
+        # Detect whether `result` is the generic default that
+        # `prev_find_question_label_func` falls back to when it can't find a
+        # real prompt ("Question 1", or its translation), so we know whether
+        # recovery should be attempted below. Matched via a regex built from
+        # the translated template with a numeric placeholder -- rather than
+        # reconstructing and exact-string-comparing one specific question
+        # number from `answer_id` -- so this doesn't depend on `answer_id`
+        # matching the platform's usual `..._<n>_<m>` format.
         try:
-            # Named to avoid babel's translation-string extraction (which
-            # matches on the literal identifier `_`/`gettext`/etc.): this
-            # reconstructs the *same* already-translated default that
-            # `prev_find_question_label_func` computes internally, purely
-            # for sentinel comparison below, so it isn't new user-facing
-            # text requiring its own catalog entry in this package.
+            # Named `gettext_fn` (not `_`) to avoid babel's translation-string
+            # extraction (which matches on the literal identifier
+            # `_`/`gettext`/etc., regardless of context -- confirmed by
+            # running `pybabel extract -F nau_openedx_extensions/locale/babel.cfg`
+            # against this file: naming it `_` does add a new `"Question {}"`
+            # msgid, `gettext_fn` doesn't). This reconstructs the *same*
+            # already-translated template `prev_find_question_label_func`
+            # uses internally, purely to detect its generic default output
+            # below, so it isn't new user-facing text requiring its own
+            # catalog entry in this package.
             gettext_fn = self.capa_system.i18n.gettext
-            question_nr = int(answer_id.split('_')[-2]) - 1
-            default_label = gettext_fn("Question {}").format(question_nr)
-        except (IndexError, ValueError):
-            default_label = None
+            default_label_template = gettext_fn("Question {}")
+            prefix, placeholder, suffix = default_label_template.partition('{}')
+            is_default_result = bool(placeholder) and re.fullmatch(
+                re.escape(prefix) + r'-?\d+' + re.escape(suffix), result or '',
+            ) is not None
+        except (AttributeError, TypeError):
+            # AttributeError: `capa_system`/`i18n` missing, or `gettext_fn`
+            # returned something without a `.partition` method (e.g. None).
+            # TypeError: `gettext_fn` itself isn't callable. Defensive: the
+            # i18n service should always be present/callable in practice,
+            # but if it isn't for some reason, log it and fall back to *not*
+            # attempting recovery for a non-empty `result` (same as the
+            # pre-existing behaviour) rather than raising.
+            log.warning(
+                "find_question_label_wrapper: couldn't determine whether "
+                "the original result is the generic default label for "
+                "answer_id=%r; skipping question-text recovery for it.",
+                answer_id, exc_info=True,
+            )
+            is_default_result = False
 
-        if result and result != default_label:
+        if result and not is_default_result:
             return result
 
         xml_elements = self.tree.xpath('//*[@id=$answer_id]', answer_id=answer_id)
@@ -273,15 +311,21 @@ def get_find_question_label_factory(prev_find_question_label_func):
 
         # Studio's rich-text/per-choice-feedback editor nests the question
         # prompt inside the response tag, as a sibling of the answer element
-        # itself -- check that location first.
-        question_text = _find_label_element_text(xml_element)
+        # itself -- check that location first. `allow_div` is only enabled
+        # for `<optioninput>` answers (multi-item "matching" problems, where
+        # each dropdown's own prompt is a `<div>` sibling), since `<div>` is
+        # too generic/common a tag to safely treat as a prompt for other
+        # response types (e.g. MCQ/checkbox).
+        question_text = _find_label_element_text(xml_element, allow_div=xml_element.tag == 'optioninput')
         if question_text:
             return question_text
 
         # Otherwise, re-check the "legacy" layout the original implementation
         # targets (the prompt as a sibling of the parent response tag), using
         # recursive text extraction in case the original only failed due to
-        # inline rich-text markup.
+        # inline rich-text markup. `<div>` is intentionally not allowed here:
+        # this layout is shared by all response types, and there's no
+        # verified/tested case of a `<div>`-wrapped prompt at this level.
         parent = xml_element.getparent()
         if parent is None:
             return result

--- a/nau_openedx_extensions/xblocks/capa_problem_responses.py
+++ b/nau_openedx_extensions/xblocks/capa_problem_responses.py
@@ -220,12 +220,29 @@ def _find_label_element_text(xml_element, allow_div=False):
     to recover per-item prompts for `<optioninput>`-based "matching"
     problems, where each dropdown's own prompt is authored as a `<div>`
     sibling immediately preceding it, not a `<p>`/`<label>`.
+
+    `<br/>`/`<hr/>` and XML comments are also skipped alongside
+    `<description>`: Studio/hand-authored OLX commonly inserts these purely
+    for layout/spacing or as authoring notes, and without skipping them the
+    positional lookup would land on one of these instead (none of which are
+    a valid label or something worth stopping at) and silently fail to find
+    the real prompt one element further back. This is intentionally a
+    narrow, explicit list of known structural/non-prompt element kinds --
+    NOT a blanket "skip any element with no text" rule, which would also
+    (unsafely) skip past a genuinely empty `<p>`/`<label>`/`<div>` slot into
+    unrelated shared/"overall instructions" content further back and return
+    the wrong text.
     """
-    SKIP_ELEMS = ('description',)
+    SKIP_ELEMS = ('description', 'br', 'hr')
     LABEL_ELEMS = ('p', 'label', 'div') if allow_div else ('p', 'label')
 
     candidate = xml_element.getprevious()
-    while candidate is not None and candidate.tag in SKIP_ELEMS:
+    while candidate is not None and (
+        candidate.tag in SKIP_ELEMS or not isinstance(candidate.tag, str)
+    ):
+        # `not isinstance(candidate.tag, str)` catches XML comment/processing
+        # instruction nodes, whose `.tag` is a callable (e.g. `etree.Comment`)
+        # rather than a string, so they'd never match `SKIP_ELEMS` by name.
         candidate = candidate.getprevious()
 
     if candidate is not None and candidate.tag in LABEL_ELEMS:

--- a/nau_openedx_extensions/xblocks/capa_problem_responses.py
+++ b/nau_openedx_extensions/xblocks/capa_problem_responses.py
@@ -100,6 +100,16 @@ log = logging.getLogger(__name__)
 # text is authored across multiple pretty-printed/indented whitespace text nodes).
 _BLANK_JOINED_TEXT_RE = re.compile(r'[\s,]*')
 
+# Element tags to skip over (in addition to non-string `.tag`s, i.e. XML
+# comment/processing-instruction nodes) when walking backwards from an
+# answer element looking for its question-prompt label -- see
+# `_find_label_element_text` below for the full rationale.
+_SKIP_ELEMS = ('description', 'br', 'hr')
+# Valid prompt-wrapper tags. `<div>` is added only when `allow_div=True`
+# (see `_find_label_element_text`'s docstring for why it's opt-in).
+_LABEL_ELEMS = ('p', 'label')
+_LABEL_ELEMS_WITH_DIV = _LABEL_ELEMS + ('div',)
+
 
 def _extract_choice_nested_text(choice_element):
     """
@@ -233,19 +243,18 @@ def _find_label_element_text(xml_element, allow_div=False):
     unrelated shared/"overall instructions" content further back and return
     the wrong text.
     """
-    SKIP_ELEMS = ('description', 'br', 'hr')
-    LABEL_ELEMS = ('p', 'label', 'div') if allow_div else ('p', 'label')
+    label_elems = _LABEL_ELEMS_WITH_DIV if allow_div else _LABEL_ELEMS
 
     candidate = xml_element.getprevious()
     while candidate is not None and (
-        candidate.tag in SKIP_ELEMS or not isinstance(candidate.tag, str)
+        candidate.tag in _SKIP_ELEMS or not isinstance(candidate.tag, str)
     ):
         # `not isinstance(candidate.tag, str)` catches XML comment/processing
         # instruction nodes, whose `.tag` is a callable (e.g. `etree.Comment`)
-        # rather than a string, so they'd never match `SKIP_ELEMS` by name.
+        # rather than a string, so they'd never match `_SKIP_ELEMS` by name.
         candidate = candidate.getprevious()
 
-    if candidate is not None and candidate.tag in LABEL_ELEMS:
+    if candidate is not None and candidate.tag in label_elems:
         text = ''.join(candidate.itertext()).strip()
         if text:
             return text
@@ -284,6 +293,20 @@ def get_find_question_label_factory(prev_find_question_label_func):
         # reconstructing and exact-string-comparing one specific question
         # number from `answer_id` -- so this doesn't depend on `answer_id`
         # matching the platform's usual `..._<n>_<m>` format.
+        #
+        # This still assumes upstream's default template is (and stays)
+        # exactly `_("Question {}")`, formatted via `str.format`, as of
+        # `LoncapaProblem.find_question_label`'s nested
+        # `generate_default_question_label()` in
+        # `xmodule/capa/capa_problem.py` (edx-platform). If that ever
+        # changes (wording, `%s`-style formatting, capitalisation, etc.),
+        # `is_default_result` silently becomes always-`False` for non-empty
+        # results and this patch stops recovering the "generic Question N"
+        # case specifically -- it would still recover the empty/`None` case
+        # below, and is never worse than the pre-patch behaviour, but the
+        # rich-text-prompt fix this PR targets would silently regress with
+        # no test/CI signal, since it depends on live upstream behaviour
+        # rather than anything in this repo.
         try:
             # Named `gettext_fn` (not `_`) to avoid babel's translation-string
             # extraction (which matches on the literal identifier


### PR DESCRIPTION
## Summary

Follow-up to fccn/nau-technical#948. After the "Resposta"/"Resposta Correta" fix (#154) was deployed to production, Carolina reported that the "Pergunta" (question) column in the "Problem Responses" report always shows a generic "Question N" / "Questão N" placeholder instead of the actual question text.

- fccn/nau-technical#948
- https://github.com/fccn/nau-openedx-extensions/pull/154

## Root cause

`LoncapaProblem.find_question_label` (edx-platform core, `xmodule/capa/capa_problem.py`) looks for the question prompt (a `<p>`/`<label>` element) as the sibling immediately **preceding the response tag itself**, e.g.:

```xml
<p>What is 2+2?</p>
<multiplechoiceresponse>
    <choicegroup id="...">...</choicegroup>
</multiplechoiceresponse>
```

But Studio's rich-text/per-choice-feedback editor (the same editor implicated in #948) instead nests the prompt **inside** the response tag, as a sibling of the choice group:

```xml
<multiplechoiceresponse>
    <p>What is 2+2?</p>
    <choicegroup id="...">...</choicegroup>
</multiplechoiceresponse>
```

so the original lookup walks up one level too many and never finds it, falling through to the "Question N" default.

A second, independent bug affects even the "expected" (sibling-of-response-tag) layout: the prompt's text is read via the element's direct `.text` node only, so a prompt authored with any inline rich-text formatting (e.g. `<p><strong>What is 2+2?</strong></p>`) also resolves to empty/`None`.

A third case, found while verifying coverage across all question types in the production course: "matching"/dropdown problems (a single `optionresponse` with several `optioninput` sub-answers) author each sub-answer's own prompt as a `<div>` sibling immediately preceding it, not a `<p>`/`<label>` — the original recovery logic didn't recognise `<div>` as a valid prompt wrapper either, so these also fell back to "Question N" for every sub-answer.

## Fix

Patches `find_question_label` (following the same monkeypatch approach already used in this module for `find_answer_text`/`find_correct_answer_text`) to:
1. Also look for the prompt as a sibling of the answer element itself, in addition to the original sibling-of-response-tag lookup.
2. Extract text recursively (via `itertext()`) instead of relying on the direct `.text` node.
3. Recognise `<div>` as a valid prompt-wrapper element, in addition to `<p>`/`<label>`, to also recover per-sub-answer prompts in `optionresponse`/matching problems.

All fall back to the original result if no real question text can be recovered, so behaviour for already-working problems is unchanged.

## Testing

- Added unit tests (`TestFindQuestionLabelFactory`, 7 tests) covering: passthrough when original result is real text, recovery for the nested-in-response-tag layout (with rich-text markup), recovery for the legacy layout with rich-text markup, no-match fallback, no-recovery-possible fallback, skipping `<description>` elements, and recovery from `<div>`-wrapped prompts in a multi-sub-answer `optionresponse`. All 17 tests in the file pass.
- `pycodestyle`, `pylint`, and `isort` all clean on the changed files.
- Verified end-to-end against the real production OLX (the `CiênciaVitae` problem from the original bug report, in the `course-v1:FCT+SERVDIG+2025_T3` test course in the local dev environment): confirmed the bug reproduces without the fix ("Questão 1"), and is resolved with the fix ("O que é o CiênciaVitae?"), calling `generate_report_data()` directly (the actual production code path used by the CSV report generator).
- **Coverage across all question types**: checked every problem in the production course tarball (36 files: 25 `multiplechoiceresponse`, 10 `choiceresponse`/checkbox, 1 `optionresponse`) — 39 answer_ids total. With this fix, **all 39 now correctly recover their real question text**, with **zero regressions**.
- **Regression check on the already-deployed #948 fix** (`extract_choices`/`find_correct_answer_text`, unrelated to this PR but re-verified while investigating question-type coverage): confirmed via synthetic OLX + real `LoncapaProblem` instantiation that `numericalresponse`, `stringresponse`, `formularesponse`, `optionresponse`, and plain/legacy (non-rich-text) MCQ problems all behave identically to the unpatched upstream — the patch's own guard clauses already exclude these response types from its recovery logic.

TODO(nau-technical#948): This is a stopgap fix for an upstream Open edX bug. Once an upstream fix lands in edx-platform/xblocks-contrib, remove these monkeypatches.
