### PR TITLE
fix: enable requirements constraint merging in setup.py and fix venv usage in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ lint-fix: | _prerequire _venv ## Fix Python import sort
 .PHONY: lint-fix
 
 # Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
-PIP_COMPILE = pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
+PIP_COMPILE = $(VENV_BIN)/pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
 
 pre-requirements: _venv ## install Python requirements for running pip-tools
 	$(PIP) install -r requirements/pip.txt
@@ -223,11 +223,11 @@ compile-requirements: pre-requirements ## Re-compile *.in requirements to *.txt
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	sed 's/Django<4.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
-	pip-compile -v --allow-unsafe ${COMPILE_OPTS} -o requirements/pip.txt requirements/pip.in
-	pip install -r requirements/pip.txt
+	$(VENV_BIN)/pip-compile -v --allow-unsafe ${COMPILE_OPTS} -o requirements/pip.txt requirements/pip.in
+	$(PIP) install -r requirements/pip.txt
 
-	pip-compile -v ${COMPILE_OPTS} -o requirements/pip-tools.txt requirements/pip-tools.in
-	pip install -r requirements/pip-tools.txt
+	$(VENV_BIN)/pip-compile -v ${COMPILE_OPTS} -o requirements/pip-tools.txt requirements/pip-tools.in
+	$(PIP) install -r requirements/pip-tools.txt
 	$(PIP_COMPILE) -o requirements/base.txt requirements/base.in
 	$(PIP_COMPILE) -o requirements/test.txt requirements/test.in
 	$(PIP_COMPILE) -o requirements/tox.txt requirements/tox.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,27 +6,27 @@
 #
 amqp==5.3.1
     # via kombu
-asgiref==3.9.1
+asgiref==3.12.1
     # via django
-attrs==25.3.0
+attrs==26.1.0
     # via openedx-events
-billiard==4.2.1
+billiard==4.2.4
     # via celery
-celery==5.5.3
+celery==5.6.3
     # via
-    #   -c /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/constraints.txt
+    #   -c /home/mdomingues/Documents/Nau/Nau-openedx-extensions/nau-openedx-extensions/requirements/constraints.txt
     #   -r requirements/base.in
-certifi==2025.7.14
+certifi==2026.7.22
     # via requests
-cffi==1.17.1
+cffi==2.1.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.2
+charset-normalizer==3.5.1
     # via requests
-click==8.2.1
+click==8.4.2
     # via
-    #   -c /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/constraints.txt
+    #   -c /home/mdomingues/Documents/Nau/Nau-openedx-extensions/nau-openedx-extensions/requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -38,11 +38,11 @@ click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-cryptography==45.0.5
+cryptography==50.0.0
     # via pyjwt
-django==4.2.23
+django==4.2.30
     # via
-    #   -c /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/constraints.txt
+    #   -c /home/mdomingues/Documents/Nau/Nau-openedx-extensions/nau-openedx-extensions/requirements/constraints.txt
     #   django-crum
     #   django-waffle
     #   djangorestframework
@@ -57,65 +57,65 @@ django-waffle==5.0.0
     # via
     #   edx-django-utils
     #   edx-drf-extensions
-djangorestframework==3.16.0
+djangorestframework==3.17.2
     # via
+    #   -c /home/mdomingues/Documents/Nau/Nau-openedx-extensions/nau-openedx-extensions/requirements/constraints.txt
     #   -r requirements/base.in
     #   drf-jwt
     #   edx-drf-extensions
-dnspython==2.7.0
+dnspython==2.8.0
     # via pymongo
 drf-jwt==1.19.2
     # via edx-drf-extensions
 edx-ccx-keys==2.0.2
     # via openedx-events
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   edx-drf-extensions
     #   openedx-events
-edx-drf-extensions==10.6.0
+edx-drf-extensions==10.7.0
     # via -r requirements/base.in
-edx-opaque-keys[django]==2.9.0
+edx-opaque-keys[django]==3.0.0
     # via
-    #   -c /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/constraints.txt
+    #   -c /home/mdomingues/Documents/Nau/Nau-openedx-extensions/nau-openedx-extensions/requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
-fastavro==1.11.1
+    #   openedx-filters
+fastavro==1.12.2
     # via openedx-events
-idna==3.10
+idna==3.19
     # via requests
-kombu==5.5.4
+kombu==5.6.2
     # via celery
-openedx-events==9.15.0
+openedx-events==10.2.0
     # via
-    #   -c /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/constraints.txt
+    #   -c /home/mdomingues/Documents/Nau/Nau-openedx-extensions/nau-openedx-extensions/requirements/constraints.txt
     #   -r requirements/base.in
-openedx-filters==1.12.0
+openedx-filters==2.0.1
     # via
-    #   -c /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/constraints.txt
+    #   -c /home/mdomingues/Documents/Nau/Nau-openedx-extensions/nau-openedx-extensions/requirements/constraints.txt
     #   -r requirements/base.in
-packaging==25.0
+packaging==26.3
     # via kombu
-pbr==6.1.1
-    # via stevedore
-prompt-toolkit==3.0.51
+prompt-toolkit==3.0.53
     # via click-repl
-psutil==7.0.0
+psutil==7.2.2
     # via edx-django-utils
-pycparser==2.22
+pycparser==3.0
     # via cffi
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.13.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
-pymongo==4.4.0
+pymongo==4.17.0
     # via edx-opaque-keys
-pynacl==1.5.0
+pynacl==1.6.2
     # via edx-django-utils
 python-dateutil==2.9.0.post0
     # via celery
-requests==2.32.4
+requests==2.34.2
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -126,26 +126,28 @@ six==1.17.0
     #   -r requirements/base.in
     #   edx-ccx-keys
     #   python-dateutil
-sqlparse==0.5.3
+sqlparse==0.6.0
     # via django
-stevedore==5.4.1
+stevedore==5.9.1
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.14.1
+typing-extensions==4.16.0
     # via edx-opaque-keys
-tzdata==2025.2
+tzdata==2026.3
     # via kombu
-urllib3==2.5.0
+tzlocal==5.4.4
+    # via celery
+urllib3==2.7.0
     # via requests
 vine==5.1.0
     # via
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.13
+wcwidth==0.8.2
     # via prompt-toolkit
-web-fragments==3.1.0
+web-fragments==4.0.0
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,3 +7,7 @@ openedx-events==10.2.0
 # pip-tools==7.4.1
 click>=8.0,<9.0
 pylint<2.16.0
+# Pinned to match fccn/openedx-platform (nau/teak.master) and to prevent
+# repeat of nau-technical#1019: djangorestframework==3.18.0 drops Django 4.2
+# support entirely, which is incompatible with the Django<5.0 pin above.
+djangorestframework<3.18.0

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,2 +1,1 @@
-celery==5.5.3
-django==4.2.23
+django==4.2.30

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ build==1.2.2.post1
     # via pip-tools
 click==8.2.1
     # via
-    #   -c /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/constraints.txt
+    #   -c /home/mdomingues/Documents/Nau/Nau-openedx-extensions/nau-openedx-extensions/requirements/constraints.txt
     #   pip-tools
 packaging==25.0
     # via build

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,211 +4,68 @@
 #
 #    make compile-requirements
 #
-amqp==5.3.1
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   kombu
-asgiref==3.9.1
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   django
-astroid==2.13.5
+asgiref==3.12.1
+    # via django
+astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
-attrs==25.3.0
+autopep8==2.3.2
+    # via -r requirements/test.in
+click==8.4.2
     # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   openedx-events
-billiard==4.2.1
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   celery
-    # via
-    #   -c /home/bryanttv/edunext/tutor/redwood/nau-local/extra-deps/nau-openedx-extensions/requirements/constraints.txt
-    #   -r /home/bryanttv/edunext/tutor/redwood/nau-local/extra-deps/nau-openedx-extensions/requirements/base.txt
-certifi==2025.7.14
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   requests
-cffi==1.17.1
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   cryptography
-    #   pynacl
-charset-normalizer==3.4.2
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   requests
-click==8.2.1
-    # via
-    #   -c /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/constraints.txt
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   celery
-    #   click-didyoumean
     #   click-log
-    #   click-plugins
-    #   click-repl
     #   code-annotations
-    #   edx-django-utils
     #   edx-lint
-click-didyoumean==0.3.1
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   celery
 click-log==0.4.0
     # via edx-lint
-click-plugins==1.1.1.2
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   celery
-click-repl==0.3.0
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   celery
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via edx-lint
-coverage==7.9.2
+coverage==7.15.4
     # via -r requirements/test.in
-cryptography==45.0.5
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   pyjwt
 ddt==1.7.2
     # via -r requirements/test.in
-dill==0.4.0
+dill==0.4.1
     # via pylint
     # via
-    #   -c /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/constraints.txt
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   django-crum
+    #   -r requirements/test.in
     #   django-mock-queries
-    #   django-waffle
     #   djangorestframework
-    #   drf-jwt
-    #   edx-django-utils
-    #   edx-drf-extensions
     #   model-bakery
-    #   openedx-events
-    #   openedx-filters
-django-crum==0.7.9
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   edx-django-utils
 django-mock-queries==2.3.0
     # via -r requirements/test.in
-django-waffle==5.0.0
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   edx-django-utils
-    #   edx-drf-extensions
-djangorestframework==3.16.0
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   django-mock-queries
-    #   drf-jwt
-    #   edx-drf-extensions
-dnspython==2.7.0
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   pymongo
-drf-jwt==1.19.2
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   edx-drf-extensions
-edx-ccx-keys==2.0.2
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   openedx-events
-edx-django-utils==8.0.0
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   edx-drf-extensions
-    #   openedx-events
-edx-drf-extensions==10.6.0
-    # via -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-edx-lint==5.6.0
+djangorestframework==3.17.2
+    # via django-mock-queries
+edx-lint==6.2.0
     # via -r requirements/test.in
-edx-opaque-keys[django]==2.9.0
-    # via
-    #   -c /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/constraints.txt
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   edx-ccx-keys
-    #   edx-drf-extensions
-    #   openedx-events
-faker==37.4.2
+faker==40.36.0
     # via -r requirements/test.in
-fastavro==1.11.1
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   openedx-events
-idna==3.10
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   requests
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via pytest
-isort==5.13.2
+isort==8.0.1
     # via pylint
 jinja2==3.1.6
     # via code-annotations
-kombu==5.5.4
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   celery
-lazy-object-proxy==1.11.0
-    # via astroid
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via jinja2
 mccabe==0.7.0
     # via pylint
-model-bakery==1.20.5
+model-bakery==1.23.5
     # via django-mock-queries
-openedx-events==9.15.0
-    # via
-    #   -c /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/constraints.txt
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-openedx-filters==1.12.0
-    # via
-    #   -c /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/constraints.txt
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-packaging==25.0
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   kombu
-    #   pytest
-pbr==6.1.1
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   stevedore
-platformdirs==4.3.8
+packaging==26.3
+    # via pytest
+platformdirs==4.11.3
     # via pylint
 pluggy==1.6.0
     # via pytest
-prompt-toolkit==3.0.51
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   click-repl
-psutil==7.0.0
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   edx-django-utils
 pycodestyle==2.14.0
-    # via -r requirements/test.in
-pycparser==2.22
     # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   cffi
-pygments==2.19.2
+    #   -r requirements/test.in
+    #   autopep8
+pygments==2.21.0
     # via pytest
-pyjwt[crypto]==2.10.1
+pylint==4.0.7
     # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   drf-jwt
-    #   edx-drf-extensions
-pylint==2.15.10
-    # via
-    #   -c /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/constraints.txt
     #   -r requirements/test.in
     #   edx-lint
     #   pylint-celery
@@ -216,85 +73,31 @@ pylint==2.15.10
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.5
+pylint-django==2.8.0
     # via edx-lint
 pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.4.0
+pytest==9.1.1
     # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   edx-opaque-keys
-pynacl==1.5.0
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   edx-django-utils
-pytest==8.4.1
+    #   -r requirements/test.in
+    #   pytest-timeout
+pytest-timeout==2.4.0
     # via -r requirements/test.in
-python-dateutil==2.9.0.post0
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   celery
 python-slugify==8.0.4
     # via code-annotations
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via code-annotations
-requests==2.32.4
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   edx-drf-extensions
-semantic-version==2.10.0
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   edx-drf-extensions
 six==1.17.0
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   edx-ccx-keys
-    #   edx-lint
-    #   python-dateutil
-sqlparse==0.5.3
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   django
-stevedore==5.4.1
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   code-annotations
-    #   edx-django-utils
-    #   edx-opaque-keys
+    # via edx-lint
+sqlparse==0.6.0
+    # via django
+stevedore==5.9.1
+    # via code-annotations
 text-unidecode==1.3
     # via python-slugify
-tomlkit==0.13.3
-    # via pylint
-typing-extensions==4.14.1
+tomlkit==0.15.1
     # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   edx-opaque-keys
-tzdata==2025.2
-    # via
-    #   -r /home/bryanttv/edunext/tutor/redwood/nau-local/extra-deps/nau-openedx-extensions/requirements/base.txt
-    #   faker
-    #   kombu
-urllib3==2.5.0
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   requests
-vine==5.1.0
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   amqp
-    #   celery
-    #   kombu
-wcwidth==0.2.13
-    # via
-    #   -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-    #   prompt-toolkit
-web-fragments==3.1.0
-    # via -r /home/edunext/edunext/naunuevocompleto/extra/nau-openedx-extensions/requirements/base.txt
-wrapt==1.17.2
-    # via astroid
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+    #   edx-lint
+    #   pylint

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,31 +4,38 @@
 #
 #    make compile-requirements
 #
-cachetools==6.1.0
-    # via tox
-chardet==5.2.0
+cachetools==7.1.7
     # via tox
 colorama==0.4.6
     # via tox
-distlib==0.3.9
+distlib==0.4.3
     # via virtualenv
-filelock==3.18.0
+filelock==3.32.3
     # via
+    #   python-discovery
     #   tox
     #   virtualenv
-packaging==25.0
+packaging==26.3
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.3.8
+platformdirs==4.11.3
     # via
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via tox
-pyproject-api==1.9.1
+pyproject-api==1.11.0
     # via tox
-tox==4.27.0
+python-discovery==1.5.2
+    # via
+    #   tox
+    #   virtualenv
+tomli-w==1.2.0
+    # via tox
+tox==4.60.0
     # via -r requirements/tox.in
-virtualenv==20.31.2
+typing-extensions==4.16.0
+    # via tox
+virtualenv==21.7.4
     # via tox

--- a/setup.py
+++ b/setup.py
@@ -11,34 +11,92 @@ from setuptools import setup
 def load_requirements(*requirements_paths):
     """
     Load all requirements from the specified requirements files.
+
+    Requirements will include any constraints from files specified
+    with -c in the requirements files.
     Returns a list of requirement strings.
     """
-    requirements = set()
+    # e.g. {"django": "Django", "confluent-kafka": "confluent_kafka[avro]"}
+    by_canonical_name = {}
+
+    def check_name_consistent(package):
+        """
+        Raise exception if package is named different ways.
+
+        This ensures that packages are named consistently so we can match
+        constraints to packages. It also ensures that if we require a package
+        with extras we don't constrain it without mentioning the extras (since
+        that too would interfere with matching constraints.)
+        """
+        canonical = package.lower().replace('_', '-').split('[')[0]
+        seen_spelling = by_canonical_name.get(canonical)
+        if seen_spelling is None:
+            by_canonical_name[canonical] = package
+        elif seen_spelling != package:
+            raise Exception(
+                f'Encountered both "{seen_spelling}" and "{package}" in requirements '
+                'and constraints files; please use just one or the other.'
+            )
+
+    requirements = {}
+    constraint_files = set()
+
+    # groups "pkg<=x.y.z,..." into ("pkg", "<=x.y.z,...")
+    re_package_name_base_chars = r"a-zA-Z0-9\-_."  # chars allowed in base package name
+    # Two groups: name[maybe,extras], and optionally a constraint
+    requirement_line_regex = re.compile(
+        r"([%s]+(?:\[[%s,\s]+\])?)([<>=][^#\s]+)?"
+        % (re_package_name_base_chars, re_package_name_base_chars)
+    )
+
+    def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
+        regex_match = requirement_line_regex.match(current_line)
+        if regex_match:
+            package = regex_match.group(1)
+            version_constraints = regex_match.group(2)
+            check_name_consistent(package)
+            existing_version_constraints = current_requirements.get(package, None)
+            # It's fine to add constraints to an unconstrained package,
+            # but raise an error if there are already constraints in place.
+            if existing_version_constraints and existing_version_constraints != version_constraints:
+                raise BaseException(f'Multiple constraint definitions found for {package}:'
+                                    f' "{existing_version_constraints}" and "{version_constraints}".'
+                                    f'Combine constraints into one location with {package}'
+                                    f'{existing_version_constraints},{version_constraints}.')
+            if add_if_not_present or package in current_requirements:
+                current_requirements[package] = version_constraints
+
+    # Read requirements from .in files and store the path to any
+    # constraint files that are pulled in.
     for path in requirements_paths:
-        requirements.update(
-            line.split('#')[0].strip() for line in open(path).readlines()
-            if is_requirement(line)
-        )
-    return list(requirements)
+        with open(path) as reqs:
+            for line in reqs:
+                if is_requirement(line):
+                    add_version_constraint_or_raise(line, requirements, True)
+                if line and line.startswith('-c') and not line.startswith('-c http'):
+                    constraint_files.add(os.path.dirname(path) + '/' + line.split('#')[0].replace('-c', '').strip())
+
+    # process constraint files: add constraints to existing requirements
+    for constraint_file in constraint_files:
+        with open(constraint_file) as reader:
+            for line in reader:
+                if is_requirement(line):
+                    add_version_constraint_or_raise(line, requirements, False)
+
+    # process back into list of pkg><=constraints strings
+    constrained_requirements = [f'{pkg}{version or ""}' for (pkg, version) in sorted(requirements.items())]
+    return constrained_requirements
 
 
 def is_requirement(line):
     """
-    Return True if the requirement line is a package requirement;
-    that is, it is not blank, a comment, or editable.
-    """
-    # Remove whitespace at the start/end of the line
-    line = line.strip()
+    Return True if the requirement line is a package requirement.
 
-    # Skip blank lines, comments, and editable installs
-    return not (
-        line == '' or
-        line.startswith('-r') or
-        line.startswith('#') or
-        line.startswith('-e') or
-        line.startswith('git+') or
-        line.startswith('-c')
-    )
+    Returns:
+        bool: True if the line is not blank, a comment,
+        a URL, or an included file
+    """
+    return line and line.strip() and not line.startswith(('-r', '#', '-e', 'git+', '-c'))
 
 
 def get_version(*file_paths):


### PR DESCRIPTION
## Problem

`nau-openedx-extensions`'s `setup.py` used an outdated `load_requirements()`/
`is_requirement()` implementation that filtered out `-c constraints.txt`
lines entirely, without ever opening or merging them. As a result, any
version pin declared in `requirements/constraints.txt` (e.g. `Django<5.0`)
was silently dropped from `install_requires` when the package was installed
via `pip install git+https://github.com/fccn/nau-openedx-extensions@...`.

This meant `djangorestframework` could resolve without any upper bound,
which is what led to the incident in nau-technical#1019 — an unconstrained
`djangorestframework` upgrade broke compatibility with our pinned
`Django<5.0` platform version.

This is not a mistake introduced by this repo's authors: `openedx` ran an
org-wide Semgrep migration to fix this exact class of bug in its own repos
(`edx-drf-extensions`, `edx-submissions`, `edx-val`, `completion`,
`edx-lint`, etc. all carry a `# UPDATED VIA SEMGREP` marker). Because
`nau-openedx-extensions` isn't part of `openedx/*`, it never received that
automated fix, and since nothing in this repo's dependency tree had — until
now — actually required a floor above what's already installed, the bug
stayed latent and unnoticed.

## Changes

- **`setup.py`**: swap `load_requirements()`/`is_requirement()` for the
  merge-capable version used upstream (`edx-drf-extensions`,
  `openedx-corporate`, etc.). This version:
  - actually opens and parses `-c` constraint files instead of discarding
    them,
  - correctly parses extras syntax (e.g. `edx-opaque-keys[django]`),
  - raises an explicit error if the same package is spelled inconsistently
    or given conflicting constraints across files,
  - returns a deterministic, sorted list instead of an unordered `set`.

  This is a drop-in swap; no other part of `setup.py` (imports, `get_version`,
  `setup(...)` metadata/entry_points) changes.

- **`requirements/constraints.txt`**: add
  `djangorestframework<3.18.0`. `djangorestframework==3.18.0` drops Django
  4.2 support entirely and requires `Django>=5.2`, which conflicts with our
  existing `Django<5.0` pin. This mirrors the identical fix already applied
  in `openedx-corporate`. No lower bound is added since nothing in this
  repo's dependency tree currently requires one (unlike `openedx-corporate`,
  which needs `>=3.15.0` because of `drf-nested-routers`).

- **`Makefile`**: fix `compile-requirements` to consistently use the
  project's venv. `PIP_COMPILE` and two `pip-compile`/`pip install` calls
  were bare (relying on `PATH`) while every other target in this file
  (`requirements`, `_run_tests`, `lint`, `lint-fix`) correctly uses
  `$(VENV_BIN)`/`$(PIP)`/`$(PYTHON)`. Previously, running
  `make compile-requirements` or `make upgrade` from a clean checkout would
  fail with `pip-compile: No such file or directory` unless the venv was
  manually activated first.

## Verification

- [ ] `make compile-requirements` (or `make upgrade`) regenerates
      `requirements/base.txt`/`test.txt`/`tox.txt` without needing to
      manually activate the venv.
- [ ] After `pip install -e .` (or an equivalent fresh install), confirm
      `Django<5.0` and `djangorestframework<3.18.0` actually appear in the
      resolved `install_requires` / installed package versions.

Refs: 
- fccn/nau-technical#1019