### PR TITLE
docs: document plaintext storage of partner API secrets

### DIFF
--- a/nau_openedx_extensions/partner_integration/docs/README.md
+++ b/nau_openedx_extensions/partner_integration/docs/README.md
@@ -49,6 +49,10 @@ The `partner_integration` module provides secure, scalable REST APIs for partner
     - Date ranges for enrollments or certificate creation
   - Invalid or unauthorized fields are removed before query execution.
 
+- **Partner Secret Storage (disclaimer)**
+  - The `PartnerAPIClient.password` field (the partner secret) is stored in **plaintext** and checked with plain string equality. This is a deliberate, documented decision, not an oversight.
+  - `PartnerAPIClient` is an API access register for partner systems, not a person's account. Keeping the secret readable lets the NAU technical team authenticate and consume the API exactly as the partner does, which is essential to reproduce and debug integration problems.
+
 - **Error Handling**
   - Custom exceptions:
     - `PartnerIntegrationInternalErrorException`

--- a/nau_openedx_extensions/partner_integration/models.py
+++ b/nau_openedx_extensions/partner_integration/models.py
@@ -38,6 +38,15 @@ class PartnerAPIClientManager(BaseUserManager):
 class PartnerAPIClient(AbstractBaseUser, PermissionsMixin):
     """
     Can authenticate via JWT and works with DRF and templates.
+
+    Security disclaimer -- plaintext ``password``:
+    This model is an API access register for partner systems, not a person's
+    account. The ``password`` (the partner secret) is deliberately stored in
+    plaintext and compared with plain string equality (see ``check_password``).
+    This is a documented operational decision, not an oversight: the NAU
+    technical team must be able to read the secret in order to authenticate
+    and consume the partner API exactly as the partner does, which is
+    essential to reproduce and debug integration problems.
     """
     name = models.CharField(max_length=100, unique=True)
     client_id = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
@@ -73,7 +82,11 @@ class PartnerAPIClient(AbstractBaseUser, PermissionsMixin):
 
     def check_password(self, password):
         """
-        Override check_password in order to have a different behavior.
+        Override check_password to compare the partner secret in plaintext.
+
+        The secret is intentionally not hashed so the NAU team can operate the
+        API as the partner does. See the class docstring and
+        https://github.com/fccn/nau-technical/issues/901 for the rationale.
         """
         return password == self.password
 


### PR DESCRIPTION
Add a security disclaimer to the PartnerAPIClient model docstring, the check_password override and the partner_integration README explaining that the partner secret is intentionally stored in plaintext so the NAU team can authenticate and consume the API exactly as a partner does.

Related to: fccn/nau-technical#901